### PR TITLE
ci: weekly workflow to refresh rules.toml from PSL + RDAP

### DIFF
--- a/.github/workflows/refresh-rules.yml
+++ b/.github/workflows/refresh-rules.yml
@@ -1,0 +1,39 @@
+name: Refresh rules
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Refresh PSL data
+        run: uv run ingest/psl.py
+
+      - name: Refresh RDAP bootstrap
+        run: uv run ingest/rdap.py
+
+      - name: Open PR if rules changed
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: refresh-rules
+          commit-message: "chore(deps): refresh rules.toml from PSL + RDAP"
+          title: "chore(deps): refresh rules.toml from PSL + RDAP"
+          body: |
+            Weekly refresh of `data/rules.toml` from upstream sources:
+            - Public Suffix List ICANN section (`ingest/psl.py`)
+            - IANA RDAP bootstrap (`ingest/rdap.py`)
+
+            Bumped automatically by `.github/workflows/refresh-rules.yml`. Merge if CI is green.
+          add-paths: data/rules.toml
+          delete-branch: true


### PR DESCRIPTION
## Summary

The README has been claiming a weekly rules refresh exists for weeks; this PR makes the claim true. Adds `.github/workflows/refresh-rules.yml`:

- Runs every Monday at 06:00 UTC (`cron: '0 6 * * 1'`)
- Manual trigger via `workflow_dispatch`
- Runs both `ingest/psl.py` (Public Suffix List) and `ingest/rdap.py` (IANA RDAP bootstrap)
- Opens a PR via `peter-evans/create-pull-request@v7` if `data/rules.toml` changed; no PR if nothing changed

## Test plan

- [x] `actionlint` clean
- [ ] First manual `workflow_dispatch` after merge to confirm it runs end-to-end and opens (or correctly skips) a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)