### PR TITLE
feat: add --version flag and tighten brew formula test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
             end
 
             test do
-              system bin/"vacant", "--help"
+              assert_match version.to_s, shell_output("#{bin}/vacant --version")
             end
           end
           RUBY

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ const BUNDLED_RULES: &str = include_str!("../data/rules.toml");
 #[derive(Parser, Debug)]
 #[command(
     name = "vacant",
+    version,
     about = "Check domain availability via authoritative DNS."
 )]
 struct Cli {


### PR DESCRIPTION
## Summary

- Wire up clap's \`version\` derive so \`vacant --version\` prints the crate version (was a no-op before).
- Brew formula test now does \`assert_match version.to_s, shell_output(\"#{bin}/vacant --version\")\` instead of just \`system bin/\"vacant\", \"--help\"\` — the test now actually verifies the installed binary matches the formula's version, not just that it executes.

## Test plan

- [x] \`cargo build --release\` clean
- [x] \`./target/release/vacant --version\` → \`vacant 0.3.1\`
- [x] \`cargo fmt --check\` + \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`actionlint\` clean
- [ ] After merge: next release ships, brew formula test exercises the version assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)