### PR TITLE
ci: validate PR titles as conventional commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,32 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            ci
+            refactor
+            perf
+            style
+            build
+            test
+          requireScope: false
+          subjectPattern: ^[a-z].+[^.]$
+          subjectPatternError: |
+            The subject "{subject}" must start with a lowercase letter and not end with a period.


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/pr-title.yml\` running \`amannn/action-semantic-pull-request@v5\` on PR open/edit/sync/reopen to require a conventional-commit-shaped title.

## Why

Without this guard, a non-conventional squash subject silently breaks the release pipeline: release-please's commit parser skips unparseable subjects, and if all the commits in a release window get skipped, no release PR opens at all.

mise-completions-sync hit this on PR #63 (\"Adopt vacant 0.3.0 release pipeline...\") — the change just sat on main, invisible to release-please. vacant has the same exposure today: squash-merge only, release-please driven off \`push:main\`, no PR-title validation in CI.

## Details

- Allowed types match the \`changelog-sections\` in \`.release-please-config.json\` exactly: feat, fix, chore, docs, ci, refactor, perf, style, build, test.
- \`subjectPattern\`: lowercase first letter, no trailing period (matches conventional-commit norms).
- Uses \`pull_request_target\` so the workflow runs against the base branch's workflow definition (safer for the GITHUB_TOKEN scope).
- Mirrors [mise-completions-sync#64](https://github.com/alltuner/mise-completions-sync/pull/64) exactly so the two repos stay in lockstep.

Closes #20

## Test plan

- [x] \`actionlint\` clean
- [ ] After merge: this PR's own title (\`ci: validate PR titles as conventional commits\`) is conventional, so the workflow will pass on subsequent edits to it
- [ ] Future non-conventional titles will fail the check and require a rename before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)