### PR TITLE
chore: switch release-please to multi-package mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,11 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      version: ${{ steps.release.outputs.version }}
+      engine_release_created: ${{ steps.release.outputs['crates/vacant--release_created'] }}
+      engine_tag_name: ${{ steps.release.outputs['crates/vacant--tag_name'] }}
+      engine_version: ${{ steps.release.outputs['crates/vacant--version'] }}
+      python_release_created: ${{ steps.release.outputs['python--release_created'] }}
+      python_tag_name: ${{ steps.release.outputs['python--tag_name'] }}
     steps:
       - uses: googleapis/release-please-action@v5
         id: release
@@ -25,18 +27,18 @@ jobs:
 
   publish-crate:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: ${{ needs.release-please.outputs.engine_release_created }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ needs.release-please.outputs.engine_tag_name }}
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo publish -p vacant --token ${{ secrets.CRATES_IO_TOKEN }}
 
   build-binaries:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: ${{ needs.release-please.outputs.engine_release_created }}
     permissions:
       contents: write
     strategy:
@@ -55,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ needs.release-please.outputs.engine_tag_name }}
 
       - uses: houseabsolute/actions-rust-cross@v1.0.7
         with:
@@ -71,18 +73,18 @@ jobs:
       - name: Upload to release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ needs.release-please.outputs.tag_name }}
+          tag_name: ${{ needs.release-please.outputs.engine_tag_name }}
           files: vacant-${{ matrix.target }}.tar.gz
 
   brew-formula:
     needs: [release-please, build-binaries]
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: ${{ needs.release-please.outputs.engine_release_created }}
     runs-on: ubuntu-latest
     steps:
       - name: Download release tarballs
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ needs.release-please.outputs.tag_name }}
+          TAG: ${{ needs.release-please.outputs.engine_tag_name }}
         run: |
           for target in aarch64-apple-darwin x86_64-apple-darwin aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu; do
             gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "vacant-$target.tar.gz"
@@ -91,7 +93,7 @@ jobs:
       - name: Generate and push formula
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          VERSION: ${{ needs.release-please.outputs.version }}
+          VERSION: ${{ needs.release-please.outputs.engine_version }}
         run: |
           MAC_ARM_SHA=$(sha256sum vacant-aarch64-apple-darwin.tar.gz | awk '{print $1}')
           MAC_INTEL_SHA=$(sha256sum vacant-x86_64-apple-darwin.tar.gz | awk '{print $1}')

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,11 +1,35 @@
 {
   "packages": {
     "crates/vacant": {
-      "changelog-path": "CHANGELOG.md",
+      "package-name": "vacant",
       "release-type": "rust",
+      "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "changelog-sections": [
+        { "type": "feat",     "section": "Features" },
+        { "type": "fix",      "section": "Bug Fixes" },
+        { "type": "refactor", "section": "Code Refactoring" },
+        { "type": "perf",     "section": "Performance Improvements" },
+        { "type": "chore",    "section": "Miscellaneous Chores" },
+        { "type": "docs",     "section": "Documentation Updates" },
+        { "type": "ci",       "section": "CI/CD Changes" },
+        { "type": "style",    "section": "Styling Changes" },
+        { "type": "build",    "section": "Build System" },
+        { "type": "test",     "section": "Tests" }
+      ]
+    },
+    "python": {
+      "package-name": "vacant-py",
+      "release-type": "python",
+      "changelog-path": "CHANGELOG.md",
+      "include-component-in-tag": true,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        { "type": "generic", "path": "../crates/vacant-py/Cargo.toml" }
+      ],
       "changelog-sections": [
         { "type": "feat",     "section": "Features" },
         { "type": "fix",      "section": "Bug Fixes" },

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,4 @@
 {
-  "crates/vacant": "0.3.3"
+  "crates/vacant": "0.3.3",
+  "python": "0.3.5"
 }


### PR DESCRIPTION
## Summary

PR 3 of the monorepo migration. Tells release-please there are now two packages in this repo: the engine at \`crates/vacant\` (rust) and the python wheel at \`python\` (python). Each tracks an independent version and tag.

## What changes

- \`.release-please-config.json\` gains a \`python\` package entry:
  - \`release-type: python\`
  - \`package-name: vacant-py\`
  - \`include-component-in-tag: true\` -> tags are \`vacant-py-vX.Y.Z\`
  - \`extra-files\` updates the \`# x-release-please-version\` magic comment in \`crates/vacant-py/Cargo.toml\` on every python release
- \`.release-please-manifest.json\` gains \`python: 0.3.5\` (matches the last vacant-py release on PyPI)
- The engine entry stays exactly as-is: \`include-component-in-tag: false\`, tags remain \`vX.Y.Z\`
- \`release.yml\` maps per-package outputs:
  - \`engine_release_created\`, \`engine_tag_name\`, \`engine_version\` <- \`crates/vacant--*\`
  - \`python_release_created\`, \`python_tag_name\` <- \`python--*\`
- The existing \`publish-crate\` / \`build-binaries\` / \`brew-formula\` jobs gate on \`engine_release_created\` so they're only triggered by engine releases

## What does NOT change yet

- No python publish job. PyPI publishing and the trusted-publisher cutover are PR 4 and PR 5.
- Tag scheme for the engine. Stays \`vX.Y.Z\` so the existing Homebrew formula URL builder keeps working.

## Why two tag schemes (\`vX.Y.Z\` vs \`vacant-py-vX.Y.Z\`)

The engine is the historical occupant of \`vX.Y.Z\` tags and the homebrew formula constructs release-asset URLs from them. Breaking that just to standardize tag style would force a homebrew formula update and risk anyone scripting \`gh release download\`. The python package gets a prefixed tag from day one in this repo so it doesn't collide.

## Test plan

- [ ] CI green on this PR (no functional change to source, just config)
- [ ] After squash-merge, watch the post-merge release run on \`main\`:
  - \`release-please\` job succeeds
  - No release PR is opened: only \`chore:\` commits exist for either package since their respective baseline versions
  - All publish/build/brew jobs are correctly skipped
- [ ] Until PR 4 wires the python publish, do not merge any \`vacant-py\` release PR if release-please opens one

🤖 Generated with [Claude Code](https://claude.com/claude-code)