### PR TITLE
fix: drop release-please extra-files cross-bump for binding crate

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -27,9 +27,6 @@
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "extra-files": [
-        { "type": "generic", "path": "../crates/vacant-py/Cargo.toml" }
-      ],
       "changelog-sections": [
         { "type": "feat",     "section": "Features" },
         { "type": "fix",      "section": "Bug Fixes" },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "vacant-py"
-version = "0.3.5"
+version = "0.0.0"
 dependencies = [
  "pyo3",
  "vacant",

--- a/crates/vacant-py/Cargo.toml
+++ b/crates/vacant-py/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
 name = "vacant-py"
-version = "0.3.5" # x-release-please-version
+version = "0.0.0"
 edition = "2021"
 license = "MIT"
 authors = ["David Poblador i Garcia <david@poblador.com>"]
 description = "PyO3 bindings for the vacant Rust engine — domain availability via authoritative DNS."
+# Internal cdylib for the python wheel; never published to crates.io. The
+# wheel's version comes from python/pyproject.toml, so this version field
+# is intentionally fixed and not synced by release-please.
 publish = false
 
 [lib]


### PR DESCRIPTION
## Summary

Hot-fix for #36's post-merge release-please failure (run [25292406834](https://github.com/alltuner/vacant/actions/runs/25292406834)). release-please rejects \`..\` in \`extra-files\` paths:

\`\`\`
##[error]release-please failed: illegal pathing characters in path: python/../crates/vacant-py/Cargo.toml
\`\`\`

So the python package's \`extra-files: [{ path: \"../crates/vacant-py/Cargo.toml\" }]\` cross-bump never works. Every push to \`main\` currently fails the release workflow on this.

## What changes

- \`.release-please-config.json\` drops the offending \`extra-files\` entry from the \`python\` package.
- \`crates/vacant-py/Cargo.toml\`: pin \`version = \"0.0.0\"\`, remove the now-pointless \`# x-release-please-version\` magic comment, and add a header comment documenting why the version is intentionally unmanaged.

## Why we can drop the cross-bump entirely

The binding crate has \`publish = false\` — it's an internal cdylib consumed only by the python wheel. Maturin reads the wheel's version from \`python/pyproject.toml\`, not from this crate's \`Cargo.toml\`. The version field in \`crates/vacant-py/Cargo.toml\` is functionally a label that nothing reads. Pinning it at \`0.0.0\` forever costs nothing.

## Verification

- \`cargo check --workspace\` clean (build picks up the version change in Cargo.lock)
- JSON config validates
- After merge, the next release-please run on \`main\` should succeed and produce no release PRs (only \`chore:\` commits since v0.3.3 / vacant-py-v0.3.5 baselines)

## Test plan

- [ ] CI green
- [ ] Post-merge release run succeeds, opens no release PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)