### PR TITLE
feat(ci): publish python wheels to PyPI on python releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,3 +155,96 @@ jobs:
               -f message="vacant: add formula at v${VERSION}" \
               -f content="$ENCODED"
           fi
+
+  build-wheels-linux:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.python_release_created }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.python_tag_name }}
+
+      - name: Mirror canonical rules into python wheel layout
+        run: cp rules/rules.toml python/vacant/rules.toml
+
+      - uses: PyO3/maturin-action@v1
+        with:
+          working-directory: python
+          target: ${{ matrix.target }}
+          manylinux: 2_28
+          args: --release --out dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-${{ matrix.target }}
+          path: python/dist
+
+  build-wheels-macos:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.python_release_created }}
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64-apple-darwin, aarch64-apple-darwin]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.python_tag_name }}
+
+      - name: Mirror canonical rules into python wheel layout
+        run: cp rules/rules.toml python/vacant/rules.toml
+
+      - uses: PyO3/maturin-action@v1
+        with:
+          working-directory: python
+          target: ${{ matrix.target }}
+          args: --release --out dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-${{ matrix.target }}
+          path: python/dist
+
+  sdist:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.python_release_created }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.python_tag_name }}
+
+      - name: Mirror canonical rules into python wheel layout
+        run: cp rules/rules.toml python/vacant/rules.toml
+
+      - uses: PyO3/maturin-action@v1
+        with:
+          working-directory: python
+          command: sdist
+          args: --out dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-sdist
+          path: python/dist
+
+  publish-pypi:
+    needs: [release-please, build-wheels-linux, build-wheels-macos, sdist]
+    if: ${{ needs.release-please.outputs.python_release_created }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: wheels-*
+          merge-multiple: true
+
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Adds the python publish path to \`release.yml\`. When release-please cuts a \`vacant-py-vX.Y.Z\` tag, this builds wheels for the standard four-target matrix, builds an sdist, and publishes everything to PyPI via OIDC trusted publishing — same pipeline alltuner/vacant-py used to run, just gated on the per-package release-please output in this monorepo.

## Jobs added

| Job | Triggers on | Builds |
|---|---|---|
| \`build-wheels-linux\` | \`python_release_created\` | x86_64 + aarch64 (manylinux 2_28) |
| \`build-wheels-macos\` | \`python_release_created\` | x86_64-apple-darwin + aarch64-apple-darwin |
| \`sdist\` | \`python_release_created\` | source distribution |
| \`publish-pypi\` | all of the above | downloads \`wheels-*\` artifacts -> \`pypa/gh-action-pypi-publish@release/v1\` with \`id-token: write\` |

Each build/sdist job:
- Checks out at \`python_tag_name\` (\`vacant-py-vX.Y.Z\`)
- Mirrors \`rules/rules.toml\` -> \`python/vacant/rules.toml\` before maturin runs (defensive; CI on main already enforces the mirror)
- Runs \`PyO3/maturin-action@v1\` with \`working-directory: python\` so maturin reads \`python/pyproject.toml\`

Engine releases skip every python job because the gates evaluate to false.

## What this does NOT do

- **Doesn't touch the engine pipeline.** \`publish-crate\`, \`build-binaries\`, \`brew-formula\` are unchanged.
- **Doesn't switch crates.io to OIDC.** That's a separate stretch we can do later.
- **Doesn't migrate the PyPI trusted publisher yet.** That's PR 5 — see below.

## What David needs to do on PyPI before this can actually publish (PR 5 prerequisite)

The PyPI trusted publisher for \`vacant\` is currently bound to \`(alltuner/vacant-py, release.yml, no environment)\`. The first time \`publish-pypi\` runs from this repo it will fail with an OIDC mismatch unless a publisher for \`(alltuner/vacant, release.yml, no environment)\` exists too.

The zero-downtime cutover (PR 5):

1. On https://pypi.org/manage/project/vacant/settings/publishing/, **add** a second trusted publisher:
   - Owner: \`alltuner\`
   - Repository name: \`vacant\`
   - Workflow filename: \`release.yml\`
   - Environment name: *(leave blank)*
2. Don't remove the old \`vacant-py\` publisher yet.
3. Cut a \`vacant-py-vX.Y.Z\` from \`alltuner/vacant\` (e.g. by merging release-please's first python release PR). Confirm the publish succeeds.
4. Once green, **delete** the \`alltuner/vacant-py\` trusted publisher entry on the same PyPI page.
5. Archive \`alltuner/vacant-py\` on GitHub with a README pointer to \`alltuner/vacant\`.

Until step 1 is done, any \`vacant-py\` release PR opened by release-please should remain unmerged.

## Verification

- YAML parses cleanly
- Diff is purely additive, 93 lines of new YAML
- All new jobs gated on \`python_release_created\`; engine pipeline unchanged
- The end-to-end test for this PR is the next python release: it will exercise the full path including the OIDC handshake with PyPI

## Test plan

- [ ] CI green on this PR (only ci.yml runs on PRs; release.yml is push-on-main)
- [ ] After squash-merge, watch the post-merge release run on \`main\`: should be a no-op (no version-bumping commits since either baseline)
- [ ] Then proceed to PR 5 (PyPI trusted-publisher cutover) — see action items above

🤖 Generated with [Claude Code](https://claude.com/claude-code)