### PR TITLE
fix(ci): drop --locked from build-binaries; bump Cargo.lock; skip-existing on pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: houseabsolute/actions-rust-cross@v1.0.7
         with:
           target: ${{ matrix.target }}
-          args: --release --locked --package vacant
+          args: --release --package vacant
           strip: true
 
       - name: Create archive
@@ -248,3 +248,5 @@ jobs:
           merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "vacant"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "clap",
  "futures",


### PR DESCRIPTION
## Summary

Hot-fixes for the v0.3.4 / vacant-py-v0.3.6 release run ([25292813715](https://github.com/alltuner/vacant/actions/runs/25292813715)). Three independent issues, all small.

## What changes

### 1. \`build-binaries\`: drop \`--locked\`

3 of 4 cross-builds failed with:
\`\`\`
error: cannot update the lock file because --locked was passed
\`\`\`
release-please bumped \`crates/vacant/Cargo.toml\` from 0.3.3 -> 0.3.4 but did not touch \`Cargo.lock\`. With \`--locked\`, cargo refuses the silent fix. (aarch64-linux happened to slip through on a stale cache hit.) \`cargo publish\` succeeded under different --locked semantics, so \`vacant 0.3.4\` is already live on crates.io — only the GitHub release binaries and brew formula are missing.

### 2. \`Cargo.lock\`: 0.3.3 -> 0.3.4

Brings the lockfile into sync with \`crates/vacant/Cargo.toml\`. This closes the immediate gap on \`main\` so subsequent CI runs don't trip the same issue even if they re-add \`--locked\` somewhere.

### 3. \`publish-pypi\`: \`skip-existing: true\`

The publish step failed with \`400 File already exists\` for \`vacant-0.3.6-cp311-abi3-macosx_10_12_x86_64.whl\`. Cause: \`vacant 0.3.6\` was already published to PyPI at 11:25 UTC today from the old \`alltuner/vacant-py\` pipeline, before we migrated. Both sides independently bumped 0.3.5 -> 0.3.6, hitting a version collision.

The OIDC handshake itself **succeeded** ("Found and verified trusted root") — that validates PR 5's whole point.

\`skip-existing: true\` makes re-runs and version coincidences non-fatal. Worth keeping permanently because PyPI never allows re-uploading the same filename anyway, so a 400 always means "already there" — not a real failure.

## Recovery plan after merge

1. Re-run the v0.3.4 build-binaries via \`gh api .../runs/25292813715/rerun-failed-jobs\` (or workflow_dispatch). The lockfile is now correct, \`--locked\` is gone, both belt and braces.
2. brew-formula will fire automatically once all four binaries upload.
3. \`vacant-py 0.3.6\` is **already on PyPI** from earlier today — nothing to do there. Next python release (0.3.7+) will exercise the from-this-repo path cleanly.

## Followup not in this PR

Long-term: add the \`cargo-workspace\` release-please plugin so it bumps \`Cargo.lock\` automatically. Worth a follow-up after the dust settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)