### PR TITLE
chore(ci): add cargo-workspace release-please plugin

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -40,5 +40,6 @@
         { "type": "test",     "section": "Tests" }
       ]
     }
-  }
+  },
+  "plugins": ["cargo-workspace"]
 }


### PR DESCRIPTION
## Summary

Adds the `cargo-workspace` plugin to `.release-please-config.json` so release-please auto-bumps `Cargo.lock` whenever any workspace member's `Cargo.toml` is bumped.

This is the root-cause fix for the v0.3.4 cross-build failure that PR #40 worked around by removing `--locked` from the cross-build job. Without this plugin, release-please rewrites `crates/vacant/Cargo.toml` from `0.3.3` to `0.3.4` but leaves `Cargo.lock` pinned to `0.3.3`, and any subsequent `cargo build --locked` rejects the mismatch.

Docs: https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#cargo-workspace

## Caveat: behavior with `crates/vacant-py` (publish = false)

The plugin reads workspace members from the root `Cargo.toml` and processes them all, regardless of whether they appear in the release-please packages map. Because `crates/vacant-py` declares `vacant = { path = "../vacant" }`, the plugin's dependency graph treats it as a dependent of `vacant` and will create a patch-bump candidate for it whenever `vacant` releases. There is no plugin option to exclude a member.

In practice this means:

- `crates/vacant-py/Cargo.toml`'s `version` field will start incrementing (`0.0.0` -> `0.0.1` -> `0.0.2` ...) on every engine release, and its `Cargo.lock` entry will follow.
- The python wheel version is unaffected; it still comes from `python/pyproject.toml` and is governed by the `python` package in release-please.
- The "intentionally fixed and not synced by release-please" comment in `crates/vacant-py/Cargo.toml` will become stale after the first release that lands after this PR. We can revisit that comment once we observe the first auto-bump.

This is option (b) from the PR plan — accept that the binding crate's internal version starts tracking. Option (a) (configure the plugin to skip it) is not supported by upstream.

## Verification

- `python3 -m json.tool < .release-please-config.json > /dev/null` passes.
- The plugin's behavior is only fully observable on a real release. The next engine release after this merges will validate that `Cargo.lock` is bumped in the release PR. Until then this is a doc-and-config change with no local way to fully exercise it.

## Follow-ups

- After the first post-merge engine release, if everything looks right we can drop the workaround commit from PR #40 and reinstate `--locked` in the cross-build.
- Update or remove the stale "intentionally fixed" comment in `crates/vacant-py/Cargo.toml` once we confirm the auto-bump behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)