### PR TITLE
feat(deps): upgrade pyo3 0.22 to 0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,15 +840,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,15 +999,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mio"
@@ -1199,37 +1181,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1237,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1249,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1813,9 +1790,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -2050,12 +2027,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/crates/vacant-py/Cargo.toml
+++ b/crates/vacant-py/Cargo.toml
@@ -16,4 +16,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 vacant = { path = "../vacant" }
-pyo3 = { version = "0.22", features = ["extension-module", "abi3-py311"] }
+pyo3 = { version = "0.28", features = ["extension-module", "abi3-py311"] }

--- a/crates/vacant-py/src/lib.rs
+++ b/crates/vacant-py/src/lib.rs
@@ -1,6 +1,5 @@
 // ABOUTME: PyO3 bindings exposing the vacant Rust engine to Python as `vacant._core`.
 // ABOUTME: Surface: load_rules(), check_many(), DiskCache. Lockstep-versioned with vacant.
-#![allow(clippy::useless_conversion)] // PyO3's `?` on PyResult triggers identity PyErr->PyErr conversion.
 
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -57,7 +56,7 @@ fn check_many(
         .as_ref()
         .ok_or_else(|| PyRuntimeError::new_err("rules not loaded; call load_rules() first"))?;
 
-    let results: Vec<CheckResult> = py.allow_threads(|| {
+    let results: Vec<CheckResult> = py.detach(|| {
         core_check_many(
             rules,
             dns,
@@ -68,9 +67,9 @@ fn check_many(
         )
     });
 
-    let list = PyList::empty_bound(py);
+    let list = PyList::empty(py);
     for r in results {
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
         dict.set_item("input", r.input)?;
         dict.set_item("domain", r.domain)?;
         dict.set_item("zone", r.zone)?;
@@ -109,7 +108,7 @@ impl PyDiskCache {
             .get(domain, ttl as i64)
             .map_err(|e| PyValueError::new_err(format!("{e}")))?;
         let Some(r) = row else { return Ok(None) };
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
         dict.set_item("domain", r.domain)?;
         dict.set_item("zone", r.zone)?;
         dict.set_item("status", r.status)?;

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -90,7 +90,7 @@ wheels = [
 
 [[package]]
 name = "vacant"
-version = "0.3.5"
+version = "0.3.6"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Upgrades the PyO3 binding crate (`crates/vacant-py`) from 0.22 to 0.28 and ports the binding source to the new API.

API porting:
- `PyDict::new_bound(py)` -> `PyDict::new(py)` (the `_bound` suffix was the 0.22 migration shim; in 0.28 the Bound API is the default)
- `PyList::empty_bound(py)` -> `PyList::empty(py)` (same reason)
- `Python::allow_threads(|| ...)` -> `Python::detach(|| ...)` (the GIL-release method was renamed in this range; closure shape is unchanged)
- Removed the `#![allow(clippy::useless_conversion)]` shim at the top of `lib.rs` -- pyo3 0.28 no longer generates an identity `PyErr -> PyErr` conversion on `?`, so clippy stays clean without it.

Supersedes #34 (Renovate's mechanical bump that hit exactly these four breakages in CI). #34 can be closed once this lands.

`crates/vacant-py` is `publish = false` (it ships only as a cdylib inside the python wheel), so the only user-visible surface affected is the `vacant` python wheel built via maturin.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --release --workspace`
- [x] `just py-check` (sync-rules + ruff format + ruff check + pytest, all green)
- [x] `just py-wheel` produces `target/wheels/vacant-0.3.6-cp311-abi3-macosx_11_0_arm64.whl`
- [x] End-to-end smoke from `python/`: `uv run python -c "from vacant import check_many; r = check_many(['google.com'])[0]; assert r.status.value in {'registered','reserved'}, r"` -> resolves as `registered` via `a.gtld-servers.net`
- [ ] CI: `rust`, `python`, `rules-sync`, `validate` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)