### PR TITLE
chore: cut unified 0.4.0 baseline (engine + python)

### DIFF
--- a/crates/vacant/CHANGELOG.md
+++ b/crates/vacant/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+<!-- Next release: 0.4.0, unified post-revamp baseline marking the monorepo migration complete. -->
+
 ## [0.3.4](https://github.com/alltuner/vacant/compare/v0.3.3...v0.3.4) (2026-05-03)
 
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+<!-- Next release: 0.4.0, unified post-revamp baseline marking the monorepo migration complete. -->
+
 ## [0.3.6](https://github.com/alltuner/vacant/compare/vacant-py-v0.3.5...vacant-py-v0.3.6) (2026-05-03)
 
 


### PR DESCRIPTION
## Summary

Marks the end of the monorepo migration with a single 0.4.0 baseline for both packages. Engine jumps 0.3.4 -> 0.4.0; python wheel jumps 0.3.6 -> 0.4.0. After this lands, version drift is back to normal independent semver — this is a one-shot lockstep, not a permanent linkage.

## Mechanism

Two commits, one per package, each touching its respective \`CHANGELOG.md\` (an invisible HTML comment so rendered changelog isn't polluted) and carrying a \`Release-As: 0.4.0\` footer in the commit body. release-please attributes each commit to its package by path (\`crates/vacant/**\` -> engine; \`python/**\` -> python wheel) and the \`Release-As\` footer overrides the default conventional-commit version math.

This is the per-commit one-shot mechanism, not the sticky \`release-as\` config field — important difference: the next release after 0.4.0 falls back to normal patch/minor bumps from conventional commits.

## Expected post-merge behavior

1. release-please walks new commits since the last release for each package
2. Sees the \`Release-As: 0.4.0\` footers and supersedes any pending release PR (#46 currently wants vacant-py 0.3.7 from the pyo3 upgrade — that gets folded into the 0.4.0 cut)
3. Opens a single \`chore: release main\` PR cutting both packages at 0.4.0
4. After we merge that PR, the full publish pipeline fires:
   - \`vacant 0.4.0\` -> crates.io + cross-built binaries on the GH release + brew formula
   - \`vacant 0.4.0\` (python) -> PyPI via OIDC

## Verification

- Local: both commits cleanly create with the expected file changes (\`+2 / -0\` per CHANGELOG)
- The HTML comment is invisible in rendered markdown and ignored by release-please's \`## \`-heading parser
- No code or workflow changes; pure metadata + content cue

## Test plan

- [ ] CI green on this PR
- [ ] After squash-merge, post-merge release-please run opens (or updates) a release PR for both packages at 0.4.0 — should supersede #46
- [ ] Merge that PR; watch the publish pipeline for both targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)