### PR TITLE
chore: cut unified 0.4.0 baseline (engine + python) — take 2

### DIFF
--- a/crates/vacant/CHANGELOG.md
+++ b/crates/vacant/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-<!-- Next release: 0.4.0, unified post-revamp baseline marking the monorepo migration complete. -->
-
 ## [0.3.4](https://github.com/alltuner/vacant/compare/v0.3.3...v0.3.4) (2026-05-03)
 
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-<!-- Next release: 0.4.0, unified post-revamp baseline marking the monorepo migration complete. -->
-
 ## [0.3.6](https://github.com/alltuner/vacant/compare/vacant-py-v0.3.5...vacant-py-v0.3.6) (2026-05-03)
 
 


### PR DESCRIPTION
## Summary

Re-attempt of #47, which got squashed into a single commit so the \`Release-As: 0.4.0\` footers ended up nested under bullets and release-please's parser ignored them. This time the PR has two top-level commits, each with the footer at the actual footer position, and **MUST be rebase-merged** (not squashed) so the per-commit footers survive on \`main\`.

## Two commits

1. \`chore(engine): cut 0.4.0 baseline\` — touches \`crates/vacant/CHANGELOG.md\`, footer \`Release-As: 0.4.0\`
2. \`chore(py): cut 0.4.0 baseline\` — touches \`python/CHANGELOG.md\`, footer \`Release-As: 0.4.0\`

Each touches its package's directory so release-please attributes the commit correctly.

The "touch" itself is the removal of the now-redundant invisible HTML comment from PR #47 (which was only useful as a marker for that attempt).

## Merge instructions

Use **rebase merge**, not squash. Each commit must land on \`main\` individually so its body+footer is preserved as a top-level commit message that release-please's parser can read. If rebase-merge is disabled on this repo, fall back to merge commit (also preserves the individual commits).

\`\`\`
gh pr merge <this> --rebase
# or, if rebase is disabled:
gh pr merge <this> --merge
\`\`\`

## Expected post-merge behavior

1. release-please walks new commits since the last release for each package
2. Sees the \`Release-As: 0.4.0\` footers and forces both packages to 0.4.0 in the next release PR (overrides default conventional-commit math that would otherwise produce 0.3.5 / 0.3.7)
3. Opens a single \`chore: release main\` PR cutting both at 0.4.0
4. Merging that PR (squash is fine — release-please commits are self-contained) triggers the full publish pipeline:
   - \`vacant 0.4.0\` -> crates.io + cross-built binaries on the GH release + brew formula
   - \`vacant 0.4.0\` (python) -> PyPI via OIDC trusted publishing

## Test plan

- [ ] CI green
- [ ] **Merged with --rebase or --merge, NOT --squash**
- [ ] Post-merge release-please run opens a PR with engine 0.4.0 + python 0.4.0
- [ ] Merge that PR → publish pipeline completes for both targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)