### PR TITLE
fix(ci): switch publish-crate to crates.io OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,14 +68,21 @@ jobs:
 
   publish-crate:
     needs: [release-please, resolve-tags]
-    if: needs.resolve-tags.outputs.engine_tag != '' && needs.release-please.outputs.engine_release_created == 'true'
+    if: needs.resolve-tags.outputs.engine_tag != ''
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ needs.resolve-tags.outputs.engine_tag }}
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish -p vacant --token ${{ secrets.CRATES_IO_TOKEN }}
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - run: cargo publish -p vacant
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   build-binaries:
     needs: [release-please, resolve-tags]


### PR DESCRIPTION
## Summary

Hot-fix for v0.4.0's failed \`publish-crate\` step ([log](https://github.com/alltuner/vacant/actions/runs/25293874397/job/74149583540)). David configured crates.io trusted publishing and revoked the \`CRATES_IO_TOKEN\` repo secret; the workflow still used the token-based publish, so it failed with:

\`\`\`
error: a value is required for '--token <TOKEN>' but none was supplied
\`\`\`

## What changes

- \`publish-crate\` job uses \`rust-lang/crates-io-auth-action@v1\` to mint a short-lived token via OIDC (\`id-token: write\` + \`contents: read\` permissions)
- \`cargo publish -p vacant\` reads \`CARGO_REGISTRY_TOKEN\` from env — no \`--token\` flag, no long-lived secret
- Gate relaxed from \`engine_release_created == 'true'\` to just \`engine_tag != ''\` so \`workflow_dispatch\` can retry a failed publish. crates.io rejects duplicate-version uploads loudly, which is the correct failure mode for "I dispatched the wrong tag" — no risk of accidentally re-publishing the same version

## Other engine-pipeline jobs (build-binaries, brew-formula) are unaffected

They never needed crates.io credentials, just a checkout and a cross-build.

## Recovery for v0.4.0

After this lands:
\`\`\`
gh workflow run release.yml -f engine_tag=v0.4.0
\`\`\`

Engine binaries + brew formula already shipped in the original run; only \`publish-crate\` needs replaying. The relaxed gate makes that a single command.

## Verification

- YAML parses
- The OIDC trusted publisher you configured on crates.io covers \`(alltuner/vacant, release.yml, no env)\` — same shape that worked for PyPI in PR 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)