### PR TITLE
chore(js): cut vacant-js 0.4.0 first release

### DIFF
--- a/js/CHANGELOG.md
+++ b/js/CHANGELOG.md
@@ -1,1 +1,3 @@
 # Changelog
+
+<!-- Initial release of @alltuner/vacant cut at the 0.4.0 unified post-monorepo baseline. -->


### PR DESCRIPTION
## Summary

Triggers the first \`@alltuner/vacant\` publish to npm, landing it at 0.4.0 in lockstep with the engine and python wheel post-monorepo baseline. Single chore commit touching \`js/CHANGELOG.md\` with \`Release-As: 0.4.0\` footer.

## Merge instructions

**Use rebase merge, not squash.** The commit's \`Release-As: 0.4.0\` footer must land on \`main\` as a top-level commit message for release-please's parser to pick it up. (Squash nests the body under bullets and the parser ignores it — exact same trap PR #50 dodged.)

\`\`\`
gh pr merge <this> --rebase
\`\`\`

## Expected post-merge sequence

1. \`release-please\` reads the \`Release-As: 0.4.0\` footer, opens a release PR cutting \`@alltuner/vacant 0.4.0\`
2. Merge that release PR (squash is fine — release-please commits are self-contained)
3. \`release.yml\` fires:
   - \`build-js-linux\` (matrix: x86_64, aarch64) and \`build-js-macos\` (matrix: x86_64, aarch64) build the napi-rs cdylib per platform
   - \`publish-npm\` performs the OIDC handshake against the pending-publisher David configured, publishes the four per-platform optional-dep packages plus the main \`@alltuner/vacant\` package with \`--provenance\`

## Risk

The OIDC handshake itself is unproven from this repo. If it fails like the crates.io case did, expect to need a small follow-up patch (action version pin, missing permission, etc.). \`skip-existing\`-style idempotency for npm publishes isn't built in — re-runs need careful handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)