### PR TITLE
fix(ci): set -march=armv8-a for aarch64-linux build-js cross-build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,6 +345,13 @@ jobs:
         working-directory: js
 
       - name: Build napi-rs binding (cross)
+        env:
+          # ring 0.17.x's ARM ASM headers require __ARM_ARCH; napi-rs's bundled
+          # cross-toolchain GCC doesn't define it implicitly, so set -march to
+          # make the assembler happy. Only affects the aarch64 target; harmless
+          # for x86_64 (env var name doesn't match).
+          CFLAGS_aarch64_unknown_linux_gnu: "-march=armv8-a"
+          CC_aarch64_unknown_linux_gnu_RING_CFLAGS: "-march=armv8-a"
         run: npx napi build --release --target ${{ matrix.target }} --platform --manifest-path ../crates/vacant-js/Cargo.toml --output-dir . --package-json-path ./package.json --js index.cjs --use-napi-cross
         working-directory: js
 


### PR DESCRIPTION
## Summary

Hot-fix for the v0.4.0 vacant-js publish run ([failed build](https://github.com/alltuner/vacant/actions/runs/25294920751/job/...)). The aarch64-unknown-linux-gnu cross-build of ring 0.17.14 fails compiling chacha-armv8 ASM because napi-rs's bundled cross-toolchain GCC doesn't define \`__ARM_ARCH\` implicitly:

\`\`\`
error: "ARM assembler must define __ARM_ARCH"
\`\`\`

## What changes

- \`.github/workflows/release.yml\`: set \`CFLAGS_aarch64_unknown_linux_gnu="-march=armv8-a"\` on the \`build-js-linux\` napi build step

The compiler then derives \`__ARM_ARCH=8\` from the architecture flag, ring's ASM preprocessor is happy, the .node binary builds, and the optionalDependency stub can publish.

Cargo's target-scoped CFLAGS env var convention means the env name only matches the aarch64 target — x86_64-linux is unaffected. The macOS aarch64 build is unaffected because Apple clang defines \`__ARM_ARCH\` unconditionally.

## Recovery for v0.4.0

After this lands:

\`\`\`
gh workflow run release.yml -f js_tag=vacant-js-v0.4.0
\`\`\`

Re-runs the four build-js jobs and publish-npm. The three already-successful builds upload artifacts again (idempotent), the failed aarch64-linux retries with the fix, publish-npm performs the OIDC handshake against npm's pending publisher.

## Risk

The other three build-js jobs from the failed run all succeeded; this is a single-target fix. If something else is wrong with publish-npm specifically, it'll only show up after build-js succeeds, and we'll iterate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)