### PR TITLE
docs: standardize README to alltuner brand structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,27 @@
-# vacant
+<h1 align="center">vacant</h1>
 
-Fast domain availability checker. Asks authoritative TLD nameservers directly instead of WHOIS.
+<p align="center">
+  <strong>Fast domain availability checker.</strong><br>
+  Asks authoritative TLD nameservers directly instead of WHOIS.
+</p>
 
-This repository hosts the engine and its language bindings:
+<p align="center">
+  <a href="https://github.com/sponsors/alltuner">Sponsor</a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/crates/v/vacant?color=5B2333" alt="crates.io">
+  <img src="https://img.shields.io/pypi/v/vacant?color=5B2333" alt="PyPI">
+  <img src="https://img.shields.io/npm/v/@alltuner/vacant?color=5B2333" alt="npm">
+  <img src="https://img.shields.io/github/license/alltuner/vacant?color=5B2333" alt="License">
+  <img src="https://img.shields.io/github/stars/alltuner/vacant?color=5B2333" alt="Stars">
+</p>
+
+---
+
+## Packages
+
+This repo is a monorepo. The same engine ships in three forms:
 
 | Package | Path | Registry |
 |---|---|---|
@@ -10,11 +29,25 @@ This repository hosts the engine and its language bindings:
 | `vacant` (Python wheel) | [`python`](python) | [PyPI](https://pypi.org/project/vacant/) |
 | `@alltuner/vacant` (npm package) | [`js`](js) | [npm](https://www.npmjs.com/package/@alltuner/vacant) |
 
-See each package's README for usage. The Python wheel embeds the Rust engine via PyO3, the npm package embeds it via napi-rs, and all three share the on-disk SQLite cache with the CLI.
+See each package's README for usage. The Python wheel embeds the Rust engine via [PyO3](https://pyo3.rs), the npm package embeds it via [napi-rs](https://napi.rs), and all three share the on-disk SQLite cache with the CLI.
 
-The PSL + RDAP-derived rules every package consumes live at [`rules/rules.toml`](rules/) — see the [`rules/` README](rules/README.md) for the source-of-truth and mirror policy.
+The [PSL](https://publicsuffix.org/) + RDAP-derived rules every package consumes live at [`rules/rules.toml`](rules/) — see the [`rules/` README](rules/README.md) for the source-of-truth and mirror policy.
 
-## Develop
+## Get Started
+
+```bash
+# Rust / CLI
+brew install alltuner/tap/vacant
+cargo install vacant
+
+# Python
+uv add vacant
+
+# JavaScript / TypeScript
+npm install @alltuner/vacant
+```
+
+## Development
 
 ```bash
 just                 # menu of all dev tasks
@@ -26,6 +59,27 @@ just js-develop      # build the napi-rs binding into js/
 just js-check        # tsc + node:test smoke
 ```
 
+## Support the project
+
+vacant is an open source project built by [David Poblador i Garcia](https://davidpoblador.com/) through [All Tuner Labs](https://www.alltuner.com/).
+
+If this project saved you a registrar lookup, consider supporting its development.
+
+❤️ **Sponsor development**
+https://github.com/sponsors/alltuner
+
+☕ **One-time support**
+https://buymeacoffee.com/alltuner
+
+Your support helps fund the continued development of vacant and other open source developer tools such as [Factory Floor](https://github.com/alltuner/factoryfloor).
+
 ## License
 
-MIT — see [`LICENSE`](LICENSE).
+[MIT](LICENSE)
+
+---
+
+<p align="center">
+  Built by <a href="https://davidpoblador.com">David Poblador i Garcia</a> with the support of <a href="https://alltuner.com">All Tuner Labs</a>.<br>
+  Made with ❤️ in Poblenou, Barcelona.
+</p>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<h1 align="center">vacant</h1>
+<p align="center">
+  <img src="https://brand.alltuner.com/logos/vacant/horizontal.png" alt="vacant" width="500">
+</p>
 
 <p align="center">
   <strong>Fast domain availability checker.</strong><br>

--- a/README.md
+++ b/README.md
@@ -59,15 +59,15 @@ just js-develop      # build the napi-rs binding into js/
 just js-check        # tsc + node:test smoke
 ```
 
+## License
+
+[MIT](LICENSE)
+
 ## Support the project
 
 vacant is an open source project built by [David Poblador i Garcia](https://davidpoblador.com/) through [All Tuner Labs](https://www.alltuner.com/).
 
 If this project was useful to you, [consider supporting its development](https://alltuner.com/sponsor).
-
-## License
-
-[MIT](LICENSE)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/sponsors/alltuner">Sponsor</a>
+  <a href="https://alltuner.com/sponsor">Sponsor</a>
 </p>
 
 <p align="center">
@@ -63,15 +63,7 @@ just js-check        # tsc + node:test smoke
 
 vacant is an open source project built by [David Poblador i Garcia](https://davidpoblador.com/) through [All Tuner Labs](https://www.alltuner.com/).
 
-If this project saved you a registrar lookup, consider supporting its development.
-
-❤️ **Sponsor development**
-https://github.com/sponsors/alltuner
-
-☕ **One-time support**
-https://buymeacoffee.com/alltuner
-
-Your support helps fund the continued development of vacant and other open source developer tools such as [Factory Floor](https://github.com/alltuner/factoryfloor).
+If this project was useful to you, [consider supporting its development](https://alltuner.com/sponsor).
 
 ## License
 


### PR DESCRIPTION
## Summary

- Adds the centered hero (title, tagline, link row, Wine-coloured shields for all three registries plus license + stars).
- Adds an explicit `## Get Started` section with the Homebrew, Cargo, uv, and npm install commands.
- Adds the canonical "Support the project" block.
- Adds the canonical centered Poblenou footer signature.

The Packages table at the top is preserved — it's the documented monorepo deviation in `alltuner/brand:readme-template`.

## Test plan

- [ ] Render on github.com and verify the centered hero, shields, and packages table.
- [ ] Confirm shield URLs resolve (crates.io, PyPI, npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)