### PR TITLE
fix(ci): bump publish-npm to Node 24 for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,7 +424,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
       - name: Mirror canonical rules into the npm layout


### PR DESCRIPTION
## Summary
- npm OIDC trusted publishing requires npm >=11.5.1.
- Node 22 LTS ships with npm 10.x; the publish silently runs without OIDC auth and the PUT 404s.
- Node 24 (LTS since 2025-10) ships with npm 11.x — bumping the publish host's Node version fixes it without an extra `npm install -g` step.

The publish-host's Node version doesn't affect what's shipped (artifacts target Node >=18). Leaving `build-js-*` on Node 22 — those only compile native bindings and don't need newer npm.

## Test plan
- [ ] Merge, then `gh workflow run release.yml -f js_tag=vacant-js-v0.4.0`
- [ ] Confirm five `@alltuner/vacant*` packages publish at 0.4.0 with provenance