### PR TITLE
fix(js): drop --skip-gh-release flag (removed in napi-rs v3)

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -28,16 +28,74 @@
       }
     },
     "node_modules/@alltuner/vacant-darwin-arm64": {
-      "optional": true
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@alltuner/vacant-darwin-arm64/-/vacant-darwin-arm64-0.4.0.tgz",
+      "integrity": "sha512-DPlw+TxHc598jai7ZOHQptdGTzBNYhD5wf5uiZLi/Q0HKQZ8pDwh5+K47ceOBgbf9QqQERfQ5o+oM4owv5gMJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@alltuner/vacant-darwin-x64": {
-      "optional": true
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@alltuner/vacant-darwin-x64/-/vacant-darwin-x64-0.4.0.tgz",
+      "integrity": "sha512-pOtKo9LC+E6y+kXJLJuCJBq97EcT7x6ehveMTtkSbSIe/dLbn7bOdUESa6DSGPSIdSvzzA3OTOQ8QJsFnmrpNg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@alltuner/vacant-linux-arm64-gnu": {
-      "optional": true
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@alltuner/vacant-linux-arm64-gnu/-/vacant-linux-arm64-gnu-0.4.0.tgz",
+      "integrity": "sha512-W7pjX49PSXxI09uEkyFu8QhivZgO7YFa20l2G6i5//XvcotWjWvEc1bRHymkgiEIaHcHrlh6bkXLA+kYzShEeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@alltuner/vacant-linux-x64-gnu": {
-      "optional": true
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@alltuner/vacant-linux-x64-gnu/-/vacant-linux-x64-gnu-0.4.0.tgz",
+      "integrity": "sha512-sfpMinbEP9Pwf/Hb/e9dqomUSuWo9Mb27LYaWb1/Hn07ENJC2R46pGN4GAxxdvBpJ2hL3SV9bi2Z8JAl6gycqA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",

--- a/js/package.json
+++ b/js/package.json
@@ -59,7 +59,7 @@
     "build": "tsup",
     "build:napi": "napi build --release --platform --manifest-path ../crates/vacant-js/Cargo.toml --output-dir . --package-json-path ./package.json --js index.cjs",
     "build:napi:debug": "napi build --platform --manifest-path ../crates/vacant-js/Cargo.toml --output-dir . --package-json-path ./package.json --js index.cjs",
-    "prepublishOnly": "napi prepublish -t npm --skip-gh-release",
+    "prepublishOnly": "napi prepublish -t npm",
     "test": "node --test tests/*.test.mjs",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## Summary
- napi-rs v3 dropped `--skip-gh-release` and inverted the default — GH releases are now opt-in via `--gh-release`.
- Our `prepublishOnly` hook still passes `--skip-gh-release`, which fails with "Unsupported option name" and breaks the main package publish.

## Test plan
- [ ] Merge, then `gh workflow run release.yml -f js_tag=vacant-js-v0.4.0`
- [ ] Confirm `@alltuner/vacant@0.4.0` publishes (the four platform stubs already published in the previous run)