### PR TITLE
fix(js): regenerate lock with --include=optional to record stub versions

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -28,16 +28,74 @@
       }
     },
     "node_modules/@alltuner/vacant-darwin-arm64": {
-      "optional": true
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@alltuner/vacant-darwin-arm64/-/vacant-darwin-arm64-0.4.0.tgz",
+      "integrity": "sha512-DPlw+TxHc598jai7ZOHQptdGTzBNYhD5wf5uiZLi/Q0HKQZ8pDwh5+K47ceOBgbf9QqQERfQ5o+oM4owv5gMJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@alltuner/vacant-darwin-x64": {
-      "optional": true
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@alltuner/vacant-darwin-x64/-/vacant-darwin-x64-0.4.0.tgz",
+      "integrity": "sha512-pOtKo9LC+E6y+kXJLJuCJBq97EcT7x6ehveMTtkSbSIe/dLbn7bOdUESa6DSGPSIdSvzzA3OTOQ8QJsFnmrpNg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@alltuner/vacant-linux-arm64-gnu": {
-      "optional": true
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@alltuner/vacant-linux-arm64-gnu/-/vacant-linux-arm64-gnu-0.4.0.tgz",
+      "integrity": "sha512-W7pjX49PSXxI09uEkyFu8QhivZgO7YFa20l2G6i5//XvcotWjWvEc1bRHymkgiEIaHcHrlh6bkXLA+kYzShEeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@alltuner/vacant-linux-x64-gnu": {
-      "optional": true
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@alltuner/vacant-linux-x64-gnu/-/vacant-linux-x64-gnu-0.4.0.tgz",
+      "integrity": "sha512-sfpMinbEP9Pwf/Hb/e9dqomUSuWo9Mb27LYaWb1/Hn07ENJC2R46pGN4GAxxdvBpJ2hL3SV9bi2Z8JAl6gycqA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -2555,9 +2555,9 @@
       ]
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/js/package.json
+++ b/js/package.json
@@ -59,7 +59,7 @@
     "build": "tsup",
     "build:napi": "napi build --release --platform --manifest-path ../crates/vacant-js/Cargo.toml --output-dir . --package-json-path ./package.json --js index.cjs",
     "build:napi:debug": "napi build --platform --manifest-path ../crates/vacant-js/Cargo.toml --output-dir . --package-json-path ./package.json --js index.cjs",
-    "prepublishOnly": "napi prepublish -t npm --skip-gh-release",
+    "prepublishOnly": "napi prepublish -t npm",
     "test": "node --test tests/*.test.mjs",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## Summary
- The previous lock had the four `@alltuner/vacant-<platform>` entries with no version/resolved fields (only `optional: true`), because npm doesn't auto-resolve optional deps that don't match the host platform.
- Result: `npm ci` fails with `Invalid: lock file's @alltuner/vacant-darwin-arm64@ does not satisfy @alltuner/vacant-darwin-arm64@0.4.0` on every CI runner.
- Regenerating with `npm install --include=optional` after the stubs were published at 0.4.0 produces a fully-resolved lock that `npm ci` accepts on every platform.

## Test plan
- [ ] Merge, then merge release-please #61 (cuts vacant-js 0.4.1)
- [ ] Confirm all five `@alltuner/vacant*` packages publish at 0.4.1