### PR TITLE
fix(ci): use napi prepublish for stub versioning + publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -455,13 +455,9 @@ jobs:
         run: npm run build
         working-directory: js
 
-      - name: Publish per-platform stubs to npm
+      - name: Sync stub versions and publish per-platform stubs (napi prepublish)
         working-directory: js
-        run: |
-          for stub in npm/*/; do
-            echo "Publishing $stub"
-            (cd "$stub" && npm publish --provenance --access public)
-          done
+        run: npx napi prepublish -t npm
 
       - name: Publish main package to npm
         working-directory: js

--- a/js/package.json
+++ b/js/package.json
@@ -59,7 +59,6 @@
     "build": "tsup",
     "build:napi": "napi build --release --platform --manifest-path ../crates/vacant-js/Cargo.toml --output-dir . --package-json-path ./package.json --js index.cjs",
     "build:napi:debug": "napi build --platform --manifest-path ../crates/vacant-js/Cargo.toml --output-dir . --package-json-path ./package.json --js index.cjs",
-    "prepublishOnly": "napi prepublish -t npm",
     "test": "node --test tests/*.test.mjs",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## Summary
- Manual `for stub in npm/*/` loop publishes each stub at its literal `version` field, which release-please doesn't bump (it only knows about `js/package.json`). After v0.4.1 was cut, the stubs still said 0.4.0 → npm rejected as "cannot publish over previously published".
- `napi prepublish` is the napi-rs tool for this: it syncs stub versions + main's `optionalDependencies` pins to the main package version, copies binaries into each stub, then publishes them.
- Drop the `prepublishOnly` hook so napi prepublish doesn't re-run inside the main publish step.

## Test plan
- [ ] Merge, then `gh workflow run release.yml -f js_tag=vacant-js-v0.4.1`
- [ ] Confirm five `@alltuner/vacant*` packages publish at 0.4.1