### PR TITLE
chore(renovate): ignore self-published napi platform stubs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,10 @@
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "groupName": "github-actions"
+    },
+    {
+      "matchPackageNames": ["@alltuner/vacant-*"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Disable Renovate for `@alltuner/vacant-*` platform stub packages
- These are this repo's own napi-rs artifacts; versions are set by `napi prepublish` at release time, so updating the source `optionalDependencies` pin is busywork that resets every release

## Test plan
- [ ] Confirm Renovate closes/skips the open stub PRs (#68, #69) on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)