### PR TITLE
fix: stop caching INVALID results (#75)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2185,6 +2185,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "toml",

--- a/crates/vacant/Cargo.toml
+++ b/crates/vacant/Cargo.toml
@@ -29,3 +29,4 @@ rusqlite = { version = "0.39", features = ["bundled"] }
 
 [dev-dependencies]
 proptest = "1"
+tempfile = "3"

--- a/crates/vacant/src/orchestrator.rs
+++ b/crates/vacant/src/orchestrator.rs
@@ -98,7 +98,7 @@ pub fn check_many(
 
     if let Some(c) = cache {
         for r in results.iter().flatten() {
-            if r.from_cache || matches!(r.status, Status::Unknown) {
+            if r.from_cache || matches!(r.status, Status::Unknown | Status::Invalid) {
                 continue;
             }
             let _ = c.put(&r.domain, &r.zone, r.status.as_str(), &r.detail);

--- a/crates/vacant/tests/cache.rs
+++ b/crates/vacant/tests/cache.rs
@@ -1,0 +1,55 @@
+// ABOUTME: End-to-end tests for the orchestrator's cache-write contract.
+// ABOUTME: Guards against re-introducing input-shape Invalid results poisoning the cache.
+
+use std::str::FromStr;
+use std::time::Duration;
+
+use tempfile::TempDir;
+use vacant::{check_many, DiskCache, DnsClient, RuleSet};
+
+const FIXTURE: &str = r#"
+[default]
+min_length = 1
+max_length = 63
+charset = "ldh"
+no_edge_hyphen = true
+no_tagged_hyphen = true
+
+[zone.com]
+"#;
+
+fn rules() -> RuleSet {
+    RuleSet::from_str(FIXTURE).expect("fixture is valid")
+}
+
+fn dns() -> DnsClient {
+    DnsClient::new(Duration::from_secs(1)).expect("dns client init")
+}
+
+#[test]
+fn invalid_below_registrable_does_not_poison_cache() {
+    let tmp = TempDir::new().expect("tempdir");
+    let cache = DiskCache::open(&tmp.path().join("results.db")).expect("open cache");
+    let rs = rules();
+    let dc = dns();
+
+    // 1) Seed the cache by checking a subdomain — precheck returns Invalid
+    //    ("below the registrable level"). No DNS is needed for the verdict.
+    let inputs = vec!["vacant.alltuner.com".to_string()];
+    let results = check_many(&rs, &dc, Some(&cache), &inputs, 86_400, 1);
+    assert_eq!(results[0].status.as_str(), "invalid");
+    assert_eq!(results[0].domain, "alltuner.com");
+
+    // 2) The cache must NOT contain a row for the registrable name —
+    //    otherwise any later query for alltuner.com (or its siblings/parents)
+    //    would surface this stale "below the registrable level" detail.
+    let row = cache.get("alltuner.com", 86_400).expect("cache get");
+    assert!(
+        row.is_none(),
+        "cache was poisoned with an Invalid result keyed by registrable name: {row:?}"
+    );
+
+    // And nothing under the input-shape key either.
+    let row = cache.get("vacant.alltuner.com", 86_400).expect("cache get");
+    assert!(row.is_none());
+}

--- a/js/src/disk-cache.ts
+++ b/js/src/disk-cache.ts
@@ -48,7 +48,12 @@ export class DiskCache {
   }
 
   put(result: Result): void {
-    if (result.status === Status.UNKNOWN || !result.domain) return
+    if (
+      result.status === Status.UNKNOWN ||
+      result.status === Status.INVALID ||
+      !result.domain
+    )
+      return
     this._inner.put(result.domain, result.zone, result.status, result.detail)
   }
 }

--- a/python/tests/test_smoke.py
+++ b/python/tests/test_smoke.py
@@ -1,4 +1,4 @@
-from vacant import Status, check, check_many
+from vacant import DiskCache, Result, Status, check, check_many
 
 
 def test_check_many_preserves_input_order_and_classifies():
@@ -13,3 +13,26 @@ def test_check_many_preserves_input_order_and_classifies():
 def test_check_single_invalid():
     r = check("nope")
     assert r.status is Status.INVALID
+
+
+def test_invalid_below_registrable_does_not_poison_cache(tmp_path):
+    cache = DiskCache(tmp_path / "results.db")
+    results = check_many(["vacant.alltuner.com"], cache=cache)
+    assert results[0].status is Status.INVALID
+    assert results[0].domain == "alltuner.com"
+    assert cache.get("alltuner.com", ttl=86_400) is None
+    assert cache.get("vacant.alltuner.com", ttl=86_400) is None
+
+
+def test_disk_cache_put_skips_invalid(tmp_path):
+    cache = DiskCache(tmp_path / "results.db")
+    cache.put(
+        Result(
+            input="vacant.alltuner.com",
+            domain="alltuner.com",
+            zone="com",
+            status=Status.INVALID,
+            detail="below the registrable level",
+        )
+    )
+    assert cache.get("alltuner.com", ttl=86_400) is None

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -90,7 +90,7 @@ wheels = [
 
 [[package]]
 name = "vacant"
-version = "0.3.6"
+version = "0.4.1"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/python/vacant/disk_cache.py
+++ b/python/vacant/disk_cache.py
@@ -41,6 +41,6 @@ class DiskCache:
         )
 
     def put(self, result: Result) -> None:
-        if result.status is Status.UNKNOWN or not result.domain:
+        if result.status in (Status.UNKNOWN, Status.INVALID) or not result.domain:
             return
         self._inner.put(result.domain, result.zone, result.status.value, result.detail)


### PR DESCRIPTION
## Summary
- INVALID is always input-shape: below registrable level, malformed, unknown TLD. It describes the input, not the zone.
- The orchestrator was writing INVALID rows keyed by the *registrable name*, so checking `vacant.alltuner.com` once poisoned the cache for `alltuner.com` and every sibling/parent for the cache TTL.
- Skip INVALID in the orchestrator's cache-write loop (Rust). Mirror the guard in the Python and JS `DiskCache.put` wrappers.

## Repro (now fixed)
```python
from vacant import check_many, DiskCache
cache = DiskCache()
check_many(['vacant.alltuner.com'], cache=cache)   # INVALID, written under 'alltuner.com'
check_many(['alltuner.com'], cache=cache)[0]        # used to be from_cache=True INVALID, now REGISTERED
```

## Test plan
- [x] New Rust integration test `crates/vacant/tests/cache.rs` — verifies the cache stays empty after an Invalid below-registrable verdict
- [x] New Python smoke tests covering both the orchestrator path and the defensive `DiskCache.put` guard
- [x] `cargo test --workspace` green
- [x] `just py-check` green
- [x] `cargo fmt --check` and `cargo clippy -D warnings` green

Fixes #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)