### PR TITLE
fix: normalize URL-shaped, IDN, and dirty inputs (#76)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,6 +2177,7 @@ dependencies = [
  "futures",
  "hickory-proto",
  "hickory-resolver",
+ "idna",
  "proptest",
  "rand 0.10.1",
  "regex",

--- a/crates/vacant/Cargo.toml
+++ b/crates/vacant/Cargo.toml
@@ -26,6 +26,7 @@ futures = "0.3"
 reqwest = { version = "0.13", default-features = false, features = ["rustls-no-provider", "http2"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 rusqlite = { version = "0.39", features = ["bundled"] }
+idna = "1"
 
 [dev-dependencies]
 proptest = "1"

--- a/crates/vacant/src/lib.rs
+++ b/crates/vacant/src/lib.rs
@@ -3,12 +3,14 @@
 
 pub mod disk_cache;
 mod dns;
+mod normalize;
 mod orchestrator;
 pub mod rdap;
 mod rules;
 
 pub use disk_cache::{CacheError, CachedRow, DiskCache};
 pub use dns::{DnsClient, DnsError, DnsVerdict, FullCheckJob, FullVerdict};
+pub use normalize::normalize_input;
 pub use orchestrator::{check_many, CheckResult};
 pub use rules::{
     LoadError, MatchResult, PreCheck, RuleSet, RuleViolation, Status, ZoneMatch, ZonePolicy,

--- a/crates/vacant/src/normalize.rs
+++ b/crates/vacant/src/normalize.rs
@@ -1,0 +1,166 @@
+// ABOUTME: Canonicalize user input into a registrable-shaped, ASCII, lowercased name.
+// ABOUTME: Tolerates pasted URLs, trailing slashes, FQDN dots, mixed case, and IDN labels.
+
+/// Canonicalize a user-supplied string into the engine's domain form.
+///
+/// Returns `None` if the input has no recoverable host (empty, or a non-ASCII
+/// label that fails IDNA encoding). The returned name is lowercase ASCII with
+/// no scheme, userinfo, port, path, query, fragment, or trailing dot.
+pub fn normalize_input(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let after_scheme = match trimmed.find("://") {
+        Some(i) => &trimmed[i + 3..],
+        None => trimmed,
+    };
+
+    let after_userinfo = match after_scheme.rfind('@') {
+        Some(i) => &after_scheme[i + 1..],
+        None => after_scheme,
+    };
+
+    let host_with_port = after_userinfo
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or(after_userinfo);
+
+    let host = strip_port(host_with_port);
+
+    let host = host.trim_end_matches('.').trim();
+    if host.is_empty() {
+        return None;
+    }
+
+    if host.is_ascii() {
+        return Some(host.to_ascii_lowercase());
+    }
+
+    idna::domain_to_ascii(host).ok()
+}
+
+/// Trim a trailing `:<port>` from a host. Leaves bracketed IPv6 literals alone.
+fn strip_port(host: &str) -> &str {
+    if host.starts_with('[') {
+        return host;
+    }
+    match host.rfind(':') {
+        Some(i) if host[i + 1..].chars().all(|c| c.is_ascii_digit()) => &host[..i],
+        _ => host,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_input;
+
+    #[test]
+    fn lowercases_ascii() {
+        assert_eq!(
+            normalize_input("ALLTUNER.COM").as_deref(),
+            Some("alltuner.com")
+        );
+    }
+
+    #[test]
+    fn trims_outer_whitespace() {
+        assert_eq!(
+            normalize_input("  alltuner.com  ").as_deref(),
+            Some("alltuner.com")
+        );
+    }
+
+    #[test]
+    fn strips_trailing_dot() {
+        assert_eq!(
+            normalize_input("alltuner.com.").as_deref(),
+            Some("alltuner.com")
+        );
+    }
+
+    #[test]
+    fn strips_url_scheme() {
+        assert_eq!(
+            normalize_input("https://alltuner.com").as_deref(),
+            Some("alltuner.com")
+        );
+        assert_eq!(
+            normalize_input("http://Alltuner.COM").as_deref(),
+            Some("alltuner.com")
+        );
+        assert_eq!(
+            normalize_input("ftp://alltuner.com").as_deref(),
+            Some("alltuner.com")
+        );
+    }
+
+    #[test]
+    fn strips_path_query_fragment() {
+        assert_eq!(
+            normalize_input("https://alltuner.com/some/path").as_deref(),
+            Some("alltuner.com")
+        );
+        assert_eq!(
+            normalize_input("alltuner.com/path?x=1#frag").as_deref(),
+            Some("alltuner.com")
+        );
+        assert_eq!(
+            normalize_input("alltuner.com/").as_deref(),
+            Some("alltuner.com")
+        );
+    }
+
+    #[test]
+    fn strips_userinfo() {
+        assert_eq!(
+            normalize_input("https://user:pass@alltuner.com/path").as_deref(),
+            Some("alltuner.com")
+        );
+        assert_eq!(
+            normalize_input("user@alltuner.com").as_deref(),
+            Some("alltuner.com")
+        );
+    }
+
+    #[test]
+    fn strips_port() {
+        assert_eq!(
+            normalize_input("alltuner.com:8080").as_deref(),
+            Some("alltuner.com")
+        );
+        assert_eq!(
+            normalize_input("https://alltuner.com:443/path").as_deref(),
+            Some("alltuner.com")
+        );
+    }
+
+    #[test]
+    fn idn_to_punycode() {
+        assert_eq!(
+            normalize_input("café.com").as_deref(),
+            Some("xn--caf-dma.com")
+        );
+        assert_eq!(
+            normalize_input("xn--caf-dma.com").as_deref(),
+            Some("xn--caf-dma.com")
+        );
+    }
+
+    #[test]
+    fn empty_returns_none() {
+        assert!(normalize_input("").is_none());
+        assert!(normalize_input("   ").is_none());
+        assert!(normalize_input("https://").is_none());
+        assert!(normalize_input(".").is_none());
+    }
+
+    #[test]
+    fn combined_messy_input() {
+        assert_eq!(
+            normalize_input("  HTTPS://User@CAFÉ.com:443/x?y=1  ").as_deref(),
+            Some("xn--caf-dma.com")
+        );
+    }
+}

--- a/crates/vacant/src/orchestrator.rs
+++ b/crates/vacant/src/orchestrator.rs
@@ -1,7 +1,9 @@
 // ABOUTME: End-to-end check pipeline: normalize, cache, precheck, batch DNS+RDAP, write back.
 // ABOUTME: Single source of truth shared by the standalone binary and the PyO3 binding.
 
-use crate::{DiskCache, DnsClient, FullCheckJob, FullVerdict, PreCheck, RuleSet, Status};
+use crate::{
+    normalize_input, DiskCache, DnsClient, FullCheckJob, FullVerdict, PreCheck, RuleSet, Status,
+};
 
 #[derive(Debug, Clone)]
 pub struct CheckResult {
@@ -25,7 +27,17 @@ pub fn check_many(
     let mut pending: Vec<(usize, String, String, Option<String>)> = Vec::new();
 
     for (i, raw) in inputs.iter().enumerate() {
-        let cleaned = raw.trim().trim_end_matches('.').to_ascii_lowercase();
+        let Some(cleaned) = normalize_input(raw) else {
+            results[i] = Some(CheckResult {
+                input: raw.clone(),
+                domain: String::new(),
+                zone: String::new(),
+                status: Status::Invalid,
+                detail: "input is empty or not a recoverable host".to_string(),
+                from_cache: false,
+            });
+            continue;
+        };
 
         if !cleaned.contains('.') {
             results[i] = Some(CheckResult {

--- a/js/tests/smoke.test.mjs
+++ b/js/tests/smoke.test.mjs
@@ -25,3 +25,25 @@ test('check on a single invalid input', () => {
   const r = check('nope')
   assert.equal(r.status, Status.INVALID)
 })
+
+test('normalizes URL-shaped and IDN inputs to a canonical domain', () => {
+  for (const raw of [
+    'https://google.com',
+    'https://google.com/',
+    'https://google.com/some/path?x=1#frag',
+    '  google.com  ',
+    'google.com.',
+    'GOOGLE.COM',
+  ]) {
+    const r = check(raw)
+    assert.equal(r.domain, 'google.com', `raw=${raw}`)
+    assert.ok(
+      r.status === Status.REGISTERED || r.status === Status.RESERVED,
+      `raw=${raw} got ${r.status}`,
+    )
+  }
+  const unicode = check('café.com')
+  const punycode = check('xn--caf-dma.com')
+  assert.equal(unicode.domain, 'xn--caf-dma.com')
+  assert.equal(unicode.status, punycode.status)
+})

--- a/python/tests/test_smoke.py
+++ b/python/tests/test_smoke.py
@@ -36,3 +36,24 @@ def test_disk_cache_put_skips_invalid(tmp_path):
         )
     )
     assert cache.get("alltuner.com", ttl=86_400) is None
+
+
+def test_normalize_strips_url_scheme_and_path():
+    for raw in (
+        "https://google.com",
+        "https://google.com/",
+        "https://google.com/some/path?x=1#frag",
+        "  google.com  ",
+        "google.com.",
+        "GOOGLE.COM",
+    ):
+        r = check(raw)
+        assert r.domain == "google.com", raw
+        assert r.status in {Status.REGISTERED, Status.RESERVED}, raw
+
+
+def test_normalize_idn_collapses_to_punycode():
+    unicode = check("café.com")
+    punycode = check("xn--caf-dma.com")
+    assert unicode.domain == "xn--caf-dma.com"
+    assert unicode.status is punycode.status


### PR DESCRIPTION
## Summary
- Pasted shapes like `https://alltuner.com`, `alltuner.com/`, `café.com`, or `ALLTUNER.COM` previously leaked URL/path/IDN bits into label validation, returning a wrong `reserved`/`invalid` status.
- Add a `normalize_input` helper that trims whitespace, strips scheme/userinfo/port/path/query/fragment, drops trailing dots/slashes, lowercases ASCII, and IDNA-encodes non-ASCII to punycode (UTS-46 via the `idna` crate).
- Wire it into the orchestrator so it runs once before cache lookup and precheck. The cache key is now the canonical form, so shape-variants collapse to the same row.
- `Result.input` still echoes the raw user string; `Result.domain` is the normalized registrable name.

## Behavior table (all now correct)
| Input | `domain` | status |
|---|---|---|
| `https://alltuner.com` | `alltuner.com` | (zone verdict) |
| `https://alltuner.com/some/path?x=1#frag` | `alltuner.com` | (zone verdict) |
| `alltuner.com/` | `alltuner.com` | (zone verdict) |
| `café.com` | `xn--caf-dma.com` | same as `xn--caf-dma.com` |
| `  ALLTUNER.COM:443  ` | `alltuner.com` | (zone verdict) |

## Test plan
- [x] New `crates/vacant/src/normalize.rs` unit tests (URL, IDN, port, userinfo, FQDN dot, mixed case, empty)
- [x] New Python smoke tests (`tests/test_smoke.py`) — URL, FQDN, mixed case, IDN equivalence
- [x] New JS smoke test (`tests/smoke.test.mjs`) — same coverage
- [x] `cargo test --workspace`, `just py-check`, `just js-check`, `cargo fmt --check`, `cargo clippy -D warnings` all green

Fixes #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)