### PR TITLE
chore(python): ship _core.pyi stub and py.typed marker

### DIFF
--- a/python/uv.lock
+++ b/python/uv.lock
@@ -90,7 +90,7 @@ wheels = [
 
 [[package]]
 name = "vacant"
-version = "0.3.6"
+version = "0.4.1"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/python/vacant/_core.pyi
+++ b/python/vacant/_core.pyi
@@ -1,0 +1,24 @@
+# ABOUTME: Type stubs for the maturin-built vacant._core extension.
+# ABOUTME: Mirrors the PyO3 surface in crates/vacant-pyext/src/lib.rs.
+
+from os import PathLike
+from typing import Any
+
+_PathLike = str | PathLike[str]
+
+def load_rules(path: _PathLike) -> None: ...
+def check_many(
+    domains: list[str],
+    *,
+    concurrency: int = 64,
+    timeout: float = 4.0,
+    cache: DiskCache | None = None,
+    cache_ttl: float = 86_400.0,
+) -> list[dict[str, Any]]: ...
+
+class DiskCache:
+    def __init__(self, path: _PathLike | None = None) -> None: ...
+    @staticmethod
+    def default_path() -> str: ...
+    def get(self, domain: str, ttl: float) -> dict[str, Any] | None: ...
+    def put(self, domain: str, zone: str, status: str, detail: str) -> None: ...


### PR DESCRIPTION
## Summary
- Type checkers (ty, mypy, pyright) had no way to see the maturin-built `vacant._core` because it ships no stub and no `py.typed`. Every consumer that imported it hit \"unresolved-import\".
- Add `python/vacant/_core.pyi` mirroring the PyO3 surface in `crates/vacant-pyext/src/lib.rs` (`load_rules`, `check_many`, `DiskCache`).
- Add an empty `python/vacant/py.typed` (PEP 561) so downstream consumers (vacant-web, etc.) actually pick up the bundled types.

## Test plan
- [x] `ty check vacant/ tests/` reports \"All checks passed!\"
- [x] `just py-check` green
- [x] Built wheel locally; both `_core.pyi` and `py.typed` ship inside it (verified with `unzip -l`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)