### PR TITLE
chore: prefix root engine tags with vacant- so the release PR labels it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       engine_tag:
-        description: "Rebuild/republish the engine pipeline for this tag (e.g. v0.3.4). Leave blank to defer to release-please."
+        description: "Rebuild/republish the engine pipeline for this tag (e.g. vacant-v0.4.3). Leave blank to defer to release-please."
         required: false
         type: string
       python_tag:

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -4,7 +4,7 @@
       "package-name": "vacant",
       "release-type": "rust",
       "changelog-path": "CHANGELOG.md",
-      "include-component-in-tag": false,
+      "include-component-in-tag": true,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [


### PR DESCRIPTION
## Summary
- Without \`include-component-in-tag\`, release-please rendered the root engine's section in the release PR as a bare \`0.4.X\` with no label, while siblings showed \`vacant-py: …\` and \`vacant-js: …\`.
- Flip \`crates/vacant\` to \`include-component-in-tag: true\` so future tags become \`vacant-vX.Y.Z\` and the PR summary picks up the \`vacant: \` prefix.
- Update the \`workflow_dispatch\` help text in \`release.yml\` to use the new tag format in its example.

## Notes / risk
- Manifest is the source of truth for current versions, so the next bump correctly starts from \`0.4.2\` per \`.release-please-manifest.json\`.
- Existing \`v0.4.X\` tags stay as-is; only future engine tags use the new prefix. The release pipeline reads the tag opaquely from \`crates/vacant--tag_name\`, so no other workflow changes are needed.

## Test plan
- [ ] Wait for release-please to rebuild its open PR and verify the engine section reads \`vacant: 0.4.3\` (or whatever the next bump is) with the proper prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)