### PR TITLE
fix(ci): align release pipeline with vacant-v tag prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,7 @@ jobs:
       - name: Generate and push formula
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAG: ${{ needs.resolve-tags.outputs.engine_tag }}
           VERSION: ${{ needs.resolve-tags.outputs.engine_version }}
         run: |
           MAC_ARM_SHA=$(sha256sum vacant-aarch64-apple-darwin.tar.gz | awk '{print $1}')
@@ -163,7 +164,7 @@ jobs:
           LINUX_ARM_SHA=$(sha256sum vacant-aarch64-unknown-linux-gnu.tar.gz | awk '{print $1}')
           LINUX_INTEL_SHA=$(sha256sum vacant-x86_64-unknown-linux-gnu.tar.gz | awk '{print $1}')
 
-          BASE_URL="https://github.com/alltuner/vacant/releases/download/v${VERSION}"
+          BASE_URL="https://github.com/alltuner/vacant/releases/download/${TAG}"
 
           FORMULA_CONTENT=$(cat <<RUBY
           class Vacant < Formula

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "crates/vacant": "0.4.1",
+  "crates/vacant": "0.4.2",
   "python": "0.4.3",
   "js": "0.4.4",
   "crates/vacant-pyext": "0.0.5",


### PR DESCRIPTION
## Summary

Two interrelated CI bugs left behind by the engine-tag rename in #81:

**1. Broken `cargo publish` on Release**

Run [25801820913](https://github.com/alltuner/vacant/actions/runs/25801820913) failed with `crate vacant@0.4.1 already exists on crates.io index`. crates.io has `vacant` at 0.4.0–0.4.2 from the pre-rename `v0.x.y` tag era, but release-please's manifest got reset and now keeps trying to re-publish versions that are already taken.

Pin `.release-please-manifest.json` `crates/vacant` to `0.4.2` (the real crates.io high-water mark). The next release-please PR will bump to **0.4.3**, which is fresh on crates.io.

**2. Broken Homebrew formula (URL/sha mismatch)**

`release.yml` `brew-formula` hardcoded `releases/download/v${VERSION}` while the actual GitHub release tag is `vacant-v${VERSION}`. Result: today's formula commit ([alltuner/homebrew-tap@2aaca7d](https://github.com/alltuner/homebrew-tap/commit/2aaca7d)) has URLs pointing at the May-4 `v0.4.1` release with sha256s computed from today's `vacant-v0.4.1` binaries. `brew install vacant` fails the checksum verification.

This has been broken since the 2026-05-04 `vacant-v0.4.0` brew update — the first formula update under the renamed tag scheme.

Fix: use `${TAG}` instead of `v${VERSION}` for the base URL.

## Test plan

- [ ] Merge to main and watch the `Release` workflow on the merge commit — `publish-crate` should be skipped (no version bump), CI should pass.
- [ ] Wait for release-please to open the next release PR. It should target `crates/vacant 0.4.3`.
- [ ] After that PR merges, watch its Release workflow: `cargo publish -p vacant` should succeed at 0.4.3, and the `brew-formula` step should produce a formula whose URLs match its sha256s.

## Follow-up (manual, not in this PR)

- Force-fix the current homebrew tap formula to point at `vacant-v0.4.1` with the correct shas, so `brew install vacant` works during the wait for 0.4.3.
- Decide whether to delete the dangling `vacant-v0.4.1` GitHub release/tag once 0.4.3 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)