### PR TITLE
fix(ci): force vacant to 0.4.3 past crates.io collisions

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "crates/vacant": "0.4.2",
+  "crates/vacant": "0.4.1",
   "python": "0.4.3",
   "js": "0.4.4",
   "crates/vacant-pyext": "0.0.5",


### PR DESCRIPTION
## Summary

Follow-up to #92. Setting the manifest to `0.4.2` was the wrong move — release-please needs a corresponding `vacant-v0.4.2` git tag to anchor on, and that tag doesn't exist. Result: release-please opened #93 proposing to *downgrade* `vacant` to 0.4.0 (which is also on crates.io — would break publish again).

This PR:

- Reverts `.release-please-manifest.json` `crates/vacant` back to `0.4.1` (matches the existing `vacant-v0.4.1` tag).
- Uses `Release-As: 0.4.3` to force the next release directly to 0.4.3, jumping past crates.io's already-published 0.4.1 and 0.4.2.

## Test plan

- [ ] Merge to main.
- [ ] Confirm release-please updates PR #93 in place (or closes it and opens a new one) targeting `vacant: 0.4.3`.
- [ ] Merge the new release-please PR; verify `cargo publish -p vacant` succeeds at 0.4.3 and brew-formula produces matching URL+sha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)