### PR TITLE
fix(vacant): bump to 0.4.3 to skip past crates.io collisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "vacant"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "clap",
  "futures",

--- a/crates/vacant/Cargo.toml
+++ b/crates/vacant/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vacant"
-version = "0.4.1"
+version = "0.4.3"
 edition = "2021"
 license = "MIT"
 authors = ["David Poblador i Garcia <david@poblador.com>"]


### PR DESCRIPTION
## Summary

Third (and final) iteration on the release-publish fix from #92, #94.

**The problem**: crates.io has `vacant` published at 0.4.0, 0.4.1, and 0.4.2 from before the engine-tag rename in #81. Release-please's manifest got reset to 0.4.0 in the rename, so subsequent runs keep proposing already-taken versions. The publish step has been failing.

**What didn't work**:
- #92 — bumped manifest to 0.4.2 to match crates.io reality. But `vacant-v0.4.2` git tag doesn't exist, so release-please couldn't anchor and proposed a *downgrade* to 0.4.0.
- #94 — reverted manifest to 0.4.1 and added a `Release-As: 0.4.3` footer to a CI-only commit. But release-please's [path-based commit attribution](https://github.com/googleapis/release-please) filtered it out — the commit only touched root files (`.github/`, `.release-please-manifest.json`), nothing under `crates/vacant/`. Release-please log: `Splitting 5 commits by path … No commits for path: crates/vacant, skipping`.

**This PR**: Bump `crates/vacant/Cargo.toml` and `Cargo.lock` directly to 0.4.3. Now the commit touches files under `crates/vacant/`, so release-please's path filter will pick it up. The `Release-As: 0.4.3` footer locks the version (so chore bumps don't drift further).

## Expected next step

After merge, the Release workflow's release-please job sees a real `fix(vacant):` commit in scope for crates/vacant + `Release-As: 0.4.3` footer. It should update PR #93 in place (or recreate it) to propose `vacant: 0.4.3`. Merging that release PR will:

1. Run `cargo publish -p vacant` against a fresh 0.4.3 version → succeeds.
2. Run `brew-formula` with the #92 fix → produces a formula with matching URL+sha.

## Test plan

- [ ] Merge to main, watch the Release workflow.
- [ ] Confirm PR #93 (or its replacement) now proposes `vacant: 0.4.3`.
- [ ] Merge the release-please PR, watch its Release run — `publish-crate` succeeds, brew formula updates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)