### PR TITLE
fix(ci): skip publish-npm on workspace-crate auto-bump tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
     steps:
       - id: pick
         env:
+          GH_TOKEN: ${{ github.token }}
           DISPATCH_ENGINE_TAG: ${{ inputs.engine_tag }}
           DISPATCH_PYTHON_TAG: ${{ inputs.python_tag }}
           DISPATCH_JS_TAG: ${{ inputs.js_tag }}
@@ -78,7 +79,21 @@ jobs:
           if [ -n "$DISPATCH_JS_TAG" ]; then
             echo "js_tag=$DISPATCH_JS_TAG" >> "$GITHUB_OUTPUT"
           elif [ "$RP_JS_CREATED" = "true" ]; then
-            echo "js_tag=$RP_JS_TAG" >> "$GITHUB_OUTPUT"
+            # The `vacant-js-` tag prefix is shared between the npm package
+            # (component=vacant-js in release-please) and the internal
+            # crates/vacant-js cdylib (workspace member with the same Cargo
+            # name). When the cargo-workspace plugin auto-bumps the cdylib
+            # on an engine release, release-please reports a "js" release
+            # for that workspace tag — but js/package.json is unchanged.
+            # Filter those out by requiring the tag's version to match
+            # js/package.json at the tagged commit.
+            RP_JS_VERSION="${RP_JS_TAG#vacant-js-v}"
+            PKG_VERSION=$(gh api "repos/$GITHUB_REPOSITORY/contents/js/package.json?ref=$RP_JS_TAG" --jq '.content' | base64 -d | jq -r '.version')
+            if [ "$RP_JS_VERSION" = "$PKG_VERSION" ]; then
+              echo "js_tag=$RP_JS_TAG" >> "$GITHUB_OUTPUT"
+            else
+              echo "::notice::Skipping JS pipeline: $RP_JS_TAG is a workspace-crate bump (js/package.json says $PKG_VERSION)"
+            fi
           fi
 
   publish-crate:


### PR DESCRIPTION
## Summary

Latent bug observed during the release of vacant 0.4.3: publish-npm fails with `npm error You cannot publish over the previously published versions: 0.4.4`. Same failure was present on the 2026-05-04 rename PR's release run — pre-existing since #81.

## Root cause

The release-please config gives the npm package `component: "vacant-js"`, producing tags like `vacant-js-v0.4.4`. The internal cdylib at `crates/vacant-js` has the same Cargo `name = "vacant-js"`. The `cargo-workspace` plugin auto-bumps the cdylib on every engine release (vacant 0.4.3 → cdylib 0.0.5 → 0.0.6), and reports that as a "js" release with tag `vacant-js-v0.0.6`. `resolve-tags` then forwards `js_tag=vacant-js-v0.0.6` to `publish-npm`, which checks out the tag, reads the (unchanged) `js/package.json` at 0.4.4, and tries to publish over the already-published 0.4.4.

The crate's `Cargo.toml` even has a comment acknowledging this: *"The cargo-workspace release-please plugin will auto-bump this version on engine releases as a side-effect; that's harmless because nothing reads it"* — except for this workflow path.

## Fix

In `resolve-tags`, compare the tag's version (`vacant-js-v${X}` → `${X}`) with `js/package.json.version` at the tagged commit. Only forward the tag to the npm pipeline if they match. Workspace-bump tags (where they differ) are skipped with an `::notice::`.

Verified against both real states:
- `vacant-js-v0.0.6` (workspace bump): tag=0.0.6 vs pkg=0.4.4 → **skip** ✓
- `vacant-js-v0.4.4` (real npm release): tag=0.4.4 vs pkg=0.4.4 → **publish** ✓

## Test plan

- [ ] Merge to main; release-please will likely auto-bump the cdylib once more eventually — confirm the next such run skips publish-npm with the notice instead of failing.
- [ ] When a real npm bump happens (js/package.json changes), confirm publish-npm runs normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)