### PR TITLE
chore(ci): drop cargo-workspace release-please plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,6 @@ jobs:
     steps:
       - id: pick
         env:
-          GH_TOKEN: ${{ github.token }}
           DISPATCH_ENGINE_TAG: ${{ inputs.engine_tag }}
           DISPATCH_PYTHON_TAG: ${{ inputs.python_tag }}
           DISPATCH_JS_TAG: ${{ inputs.js_tag }}
@@ -79,21 +78,7 @@ jobs:
           if [ -n "$DISPATCH_JS_TAG" ]; then
             echo "js_tag=$DISPATCH_JS_TAG" >> "$GITHUB_OUTPUT"
           elif [ "$RP_JS_CREATED" = "true" ]; then
-            # The `vacant-js-` tag prefix is shared between the npm package
-            # (component=vacant-js in release-please) and the internal
-            # crates/vacant-js cdylib (workspace member with the same Cargo
-            # name). When the cargo-workspace plugin auto-bumps the cdylib
-            # on an engine release, release-please reports a "js" release
-            # for that workspace tag — but js/package.json is unchanged.
-            # Filter those out by requiring the tag's version to match
-            # js/package.json at the tagged commit.
-            RP_JS_VERSION="${RP_JS_TAG#vacant-js-v}"
-            PKG_VERSION=$(gh api "repos/$GITHUB_REPOSITORY/contents/js/package.json?ref=$RP_JS_TAG" --jq '.content' | base64 -d | jq -r '.version')
-            if [ "$RP_JS_VERSION" = "$PKG_VERSION" ]; then
-              echo "js_tag=$RP_JS_TAG" >> "$GITHUB_OUTPUT"
-            else
-              echo "::notice::Skipping JS pipeline: $RP_JS_TAG is a workspace-crate bump (js/package.json says $PKG_VERSION)"
-            fi
+            echo "js_tag=$RP_JS_TAG" >> "$GITHUB_OUTPUT"
           fi
 
   publish-crate:

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -61,6 +61,5 @@
         { "type": "test",     "section": "Tests" }
       ]
     }
-  },
-  "plugins": ["cargo-workspace"]
+  }
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,5 @@
 {
   "crates/vacant": "0.4.3",
   "python": "0.4.3",
-  "js": "0.4.4",
-  "crates/vacant-pyext": "0.0.6",
-  "crates/vacant-js": "0.0.6"
+  "js": "0.4.4"
 }

--- a/crates/vacant-js/Cargo.toml
+++ b/crates/vacant-js/Cargo.toml
@@ -6,9 +6,10 @@ license = "MIT"
 authors = ["David Poblador i Garcia <david@poblador.com>"]
 description = "napi-rs bindings for the vacant Rust engine — domain availability via authoritative DNS."
 # Internal cdylib for the npm package; never published to crates.io. The npm
-# package's version comes from js/package.json. The cargo-workspace
-# release-please plugin will auto-bump this version on engine releases as
-# a side-effect; that's harmless because nothing reads it.
+# package's version comes from js/package.json — this version field is
+# unused at runtime and intentionally frozen, so the release pipeline does
+# not create stray vacant-js-v0.0.* tags that collide with real npm
+# release tags.
 publish = false
 
 [lib]

--- a/crates/vacant-pyext/Cargo.toml
+++ b/crates/vacant-pyext/Cargo.toml
@@ -6,9 +6,8 @@ license = "MIT"
 authors = ["David Poblador i Garcia <david@poblador.com>"]
 description = "PyO3 bindings for the vacant Rust engine — domain availability via authoritative DNS."
 # Internal cdylib for the python wheel; never published to crates.io. The
-# wheel's version comes from python/pyproject.toml. The cargo-workspace
-# release-please plugin will auto-bump this version on engine releases as
-# a side-effect; that's harmless because nothing reads it.
+# wheel's version comes from python/pyproject.toml — this version field is
+# unused at runtime and intentionally frozen by release-please config.
 publish = false
 
 [lib]


### PR DESCRIPTION
## Summary

Permanent fix for the ghost-release / publish-npm-collision saga. The `cargo-workspace` release-please plugin exists to propagate version bumps across workspace members that depend on each other — but in this repo, both internal cdylibs use pure path deps:

```toml
# crates/vacant-js/Cargo.toml, crates/vacant-pyext/Cargo.toml
[dependencies]
vacant = { path = "../vacant" }
```

No version constraint, so there's nothing for the plugin to propagate. Its only observable effect was auto-bumping the cdylibs on every engine release and creating `vacant-js-v0.0.x` / `vacant-pyext-v0.0.x` ghost tags+releases.

For `crates/vacant-js` the ghost tag also collided with the npm release component (`component: "vacant-js"` in `.release-please-config.json`), causing `publish-npm` to repeatedly try to re-publish `@alltuner/vacant@0.4.4` over itself and fail.

## Changes

- Remove `"plugins": ["cargo-workspace"]` from `.release-please-config.json`.
- Remove the now-unused `crates/vacant-pyext` and `crates/vacant-js` entries from `.release-please-manifest.json`.
- Both internal cdylibs' `version` fields stay frozen at `0.0.6` (they're `publish = false`; nothing reads them at runtime). Update their Cargo.toml comments to reflect the new reality.
- Revert the resolve-tags heuristic added in #96 — it was filtering workspace-bump tags that will no longer be created.

## Verification that the three real publish flows still work

- **`vacant` on crates.io**: driven by the `crates/vacant` path entry. Untouched.
- **`vacant-py` on PyPI**: driven by the `python` path entry. maturin builds `crates/vacant-pyext` via `--manifest-path` — the cdylib's frozen version is unused at runtime.
- **`@alltuner/vacant` on npm**: driven by the `js` path entry. napi-rs builds `crates/vacant-js` via `--manifest-path` — same story.
- **Cross-package attribution** (e.g. `chore(deps): refresh rules.toml` simultaneously bumping all three real packages, as in #88): comes from release-please's default path-filter behavior, not from the cargo-workspace plugin. Unaffected.

## Future footgun

If you ever add a versioned path dep like `vacant = { path = "../vacant", version = "^0.4" }`, you'd have to manually update the version constraint when `vacant` bumps. The cargo-workspace plugin would have done that automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)