### PR TITLE
fix: stop reporting held domains as available; add --verify

### DIFF
--- a/crates/vacant-js/src/lib.rs
+++ b/crates/vacant-js/src/lib.rs
@@ -67,10 +67,12 @@ pub fn check_many(
     timeout: Option<f64>,
     cache: Option<&JsDiskCache>,
     cache_ttl: Option<f64>,
+    verify: Option<bool>,
 ) -> Result<Vec<CheckRow>> {
     let concurrency = concurrency.unwrap_or(64) as usize;
     let timeout = timeout.unwrap_or(4.0);
     let cache_ttl = cache_ttl.unwrap_or(86_400.0);
+    let verify = verify.unwrap_or(false);
 
     let dur = Duration::from_secs_f64(timeout.max(0.05));
     let dns = dns_client(dur)?;
@@ -93,6 +95,7 @@ pub fn check_many(
         &domains,
         cache_ttl as i64,
         concurrency,
+        verify,
     );
 
     Ok(results.into_iter().map(CheckRow::from).collect())

--- a/crates/vacant-pyext/src/lib.rs
+++ b/crates/vacant-pyext/src/lib.rs
@@ -36,7 +36,7 @@ fn load_rules(path: PathBuf) -> PyResult<()> {
 }
 
 #[pyfunction]
-#[pyo3(signature = (domains, concurrency=64, timeout=4.0, cache=None, cache_ttl=86_400.0))]
+#[pyo3(signature = (domains, concurrency=64, timeout=4.0, cache=None, cache_ttl=86_400.0, verify=false))]
 fn check_many(
     py: Python<'_>,
     domains: Vec<String>,
@@ -44,6 +44,7 @@ fn check_many(
     timeout: f64,
     cache: Option<&PyDiskCache>,
     cache_ttl: f64,
+    verify: bool,
 ) -> PyResult<Py<PyList>> {
     let dur = Duration::from_secs_f64(timeout.max(0.05));
     let dns = dns_client(dur)?;
@@ -64,6 +65,7 @@ fn check_many(
             &domains,
             cache_ttl as i64,
             concurrency,
+            verify,
         )
     });
 

--- a/crates/vacant/README.md
+++ b/crates/vacant/README.md
@@ -35,15 +35,26 @@ vacant -o table example.com
 # include zone, raw input, detail, cache hit
 vacant --detail example.com
 
-# only show available results
-vacant --available a.com b.com c.com
+# confirm undelegated names against the registry (RDAP)
+vacant --verify example.com
+
+# only show available results (implies you want the truth — pair with --verify)
+vacant --verify --available a.com b.com c.com
 
 # tighten timeout, raise concurrency for large batches
 vacant --timeout 2 --concurrency 256 < big-list.txt
 ```
 
+A name with no delegation reports `unconfirmed`, not `available`: the DNS
+answer for a free name and a held/suspended/pending-delete one is identical
+(both NXDOMAIN), so "not delegated" isn't the same claim as "registrable". Pass
+`--verify` to confirm those names against the registry's RDAP endpoint, which
+promotes them to `available` (RDAP 404) or `registered` (RDAP 200, e.g. a domain
+on hold). `available` therefore only ever means RDAP-confirmed registrable.
+
 Exit codes: `0` on success, `2` if any result has `status=unknown` (transport
-failure, ambiguous registry response).
+failure, ambiguous registry response). `unconfirmed` is a normal result and does
+not affect the exit code.
 
 ## How it works
 
@@ -54,9 +65,12 @@ For each input:
    (e.g. `.eu` minimum 3 characters), and registry suffixes used as inputs
    (`co.uk` is not a registrable name).
 2. **Authoritative NS query** against the parent zone's nameservers, with
-   `+norecurse`. NS delegation present → `registered`. NXDOMAIN → `available`.
-3. **RDAP fallback** for registries that use compact denial of existence
-   (Nominet `.uk`, several others) where step 2 returns NODATA.
+   `+norecurse`. NS delegation present → `registered` (a hard fact). NXDOMAIN or
+   NODATA → `unconfirmed`: not delegated, probably free, but not verified.
+3. **RDAP confirmation** (only with `--verify`) for the `unconfirmed` names, when
+   the zone has an RDAP endpoint: 404 → `available`, 200 → `registered`,
+   inconclusive → stays `unconfirmed`. Without `--verify` no RDAP traffic happens
+   at all, so delegated (taken) names cost zero RDAP either way.
 
 Per-host nameserver cooldowns (5 min after a transport failure) and per-RDAP-host
 throttling (2 concurrent + 100ms gap) keep things polite under heavy use.

--- a/crates/vacant/src/dns.rs
+++ b/crates/vacant/src/dns.rs
@@ -180,6 +180,7 @@ impl DnsClient {
         &self,
         jobs: Vec<FullCheckJob>,
         concurrency: usize,
+        verify: bool,
     ) -> Vec<FullVerdict> {
         let resolver = self.resolver.clone();
         let http = self.http.clone();
@@ -198,7 +199,7 @@ impl DnsClient {
                     let h = health.clone();
                     tokio::spawn(async move {
                         let _permit = sem.acquire_owned().await.expect("semaphore not closed");
-                        run_full_job(&res, &http, &throttle, &h, job, timeout).await
+                        run_full_job(&res, &http, &throttle, &h, job, timeout, verify).await
                     })
                 })
                 .collect();
@@ -214,6 +215,54 @@ impl DnsClient {
     }
 }
 
+/// What to do with a DNS verdict before any RDAP network call.
+///
+/// A delegation is a hard "registered". A DNS failure is a hard "failure". But
+/// "not in the zone" (NXDOMAIN) and "in the zone, no NS" (NODATA) only tell us a
+/// name isn't *delegated* — not whether it's *registrable*. Held, suspended, and
+/// pending-delete domains are registered yet answer NXDOMAIN, so we never call
+/// those "available" on DNS alone. Without `--verify` they stay `unconfirmed`;
+/// with `--verify` and an RDAP endpoint we confirm against the registry.
+#[derive(Debug, PartialEq, Eq)]
+enum Decision {
+    Report(&'static str),
+    Confirm,
+}
+
+fn decide(verdict: &DnsVerdict, verify: bool, has_rdap: bool) -> Decision {
+    match verdict {
+        DnsVerdict::Registered { .. } => Decision::Report("registered"),
+        DnsVerdict::Failure { .. } => Decision::Report("failure"),
+        DnsVerdict::Available { .. } | DnsVerdict::Nodata { .. } => {
+            if verify && has_rdap {
+                Decision::Confirm
+            } else {
+                Decision::Report("unconfirmed")
+            }
+        }
+    }
+}
+
+/// Fold an RDAP probe result into a final verdict. Only the registry can promote
+/// an undelegated name to `available` (404) or `registered` (200); an inconclusive
+/// probe leaves it `unconfirmed`.
+fn combine_rdap(base_detail: &str, outcome: Option<RdapOutcome>) -> FullVerdict {
+    match outcome {
+        Some(RdapOutcome::Registered { detail }) => FullVerdict {
+            kind: "registered",
+            detail: format!("{base_detail}; {detail}"),
+        },
+        Some(RdapOutcome::Available { detail }) => FullVerdict {
+            kind: "available",
+            detail: format!("{base_detail}; {detail}"),
+        },
+        None => FullVerdict {
+            kind: "unconfirmed",
+            detail: format!("{base_detail}; RDAP inconclusive"),
+        },
+    }
+}
+
 async fn run_full_job(
     resolver: &TokioResolver,
     http: &reqwest::Client,
@@ -221,52 +270,49 @@ async fn run_full_job(
     health: &HostHealth,
     job: FullCheckJob,
     timeout: Duration,
+    verify: bool,
 ) -> FullVerdict {
     let dns =
         check_authoritative_async(resolver, health, &job.zone, &job.registered, timeout).await;
-    match dns {
-        DnsVerdict::Registered { detail } => FullVerdict {
+    let detail = match &dns {
+        DnsVerdict::Registered { detail }
+        | DnsVerdict::Available { detail }
+        | DnsVerdict::Failure { detail }
+        | DnsVerdict::Nodata { detail } => detail.clone(),
+    };
+    match decide(&dns, verify, job.rdap_url.is_some()) {
+        Decision::Report("registered") => FullVerdict {
             kind: "registered",
             detail,
         },
-        DnsVerdict::Available { detail } => FullVerdict {
-            kind: "available",
-            detail,
-        },
-        DnsVerdict::Failure { detail } => FullVerdict {
+        Decision::Report("failure") => FullVerdict {
             kind: "failure",
             detail,
         },
-        DnsVerdict::Nodata { detail } => match job.rdap_url {
-            Some(base) => {
-                let host = rdap_host(&base).unwrap_or_else(|| base.clone());
-                let semaphore = throttle.permit_for(&host);
-                let permit = semaphore.acquire_owned().await.expect("rdap permit");
-                let outcome = rdap::lookup(http, &job.registered, &base).await;
-                // Hold the permit for a short cool-down so back-to-back tasks don't
-                // race the same host. drop(permit) happens after the sleep.
-                tokio::time::sleep(RDAP_PER_HOST_MIN_GAP).await;
-                drop(permit);
-                match outcome {
-                    Some(RdapOutcome::Registered { detail: rdetail }) => FullVerdict {
-                        kind: "registered",
-                        detail: format!("{detail}; {rdetail}"),
-                    },
-                    Some(RdapOutcome::Available { detail: rdetail }) => FullVerdict {
-                        kind: "available",
-                        detail: format!("{detail}; {rdetail}"),
-                    },
-                    None => FullVerdict {
-                        kind: "available",
-                        detail: format!("{detail}; RDAP inconclusive"),
-                    },
-                }
+        Decision::Report(_) => {
+            // Undelegated and not confirmed: probably free, but unverified.
+            let detail = if verify {
+                format!("{detail} (no RDAP endpoint for zone '{}')", job.zone)
+            } else {
+                detail
+            };
+            FullVerdict {
+                kind: "unconfirmed",
+                detail,
             }
-            None => FullVerdict {
-                kind: "available",
-                detail: format!("{detail} (no RDAP configured for zone '{}')", job.zone),
-            },
-        },
+        }
+        Decision::Confirm => {
+            let base = job.rdap_url.expect("confirm implies an rdap endpoint");
+            let host = rdap_host(&base).unwrap_or_else(|| base.clone());
+            let semaphore = throttle.permit_for(&host);
+            let permit = semaphore.acquire_owned().await.expect("rdap permit");
+            let outcome = rdap::lookup(http, &job.registered, &base).await;
+            // Hold the permit for a short cool-down so back-to-back tasks don't
+            // race the same host. drop(permit) happens after the sleep.
+            tokio::time::sleep(RDAP_PER_HOST_MIN_GAP).await;
+            drop(permit);
+            combine_rdap(&detail, outcome)
+        }
     }
 }
 
@@ -424,5 +470,124 @@ fn classify(response: &Message, ns: &str) -> Option<DnsVerdict> {
             }
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn available() -> DnsVerdict {
+        DnsVerdict::Available {
+            detail: "NXDOMAIN via ns1".to_string(),
+        }
+    }
+    fn nodata() -> DnsVerdict {
+        DnsVerdict::Nodata {
+            detail: "NODATA via ns1".to_string(),
+        }
+    }
+    fn registered() -> DnsVerdict {
+        DnsVerdict::Registered {
+            detail: "delegation via ns1".to_string(),
+        }
+    }
+    fn failure() -> DnsVerdict {
+        DnsVerdict::Failure {
+            detail: "all nameservers failed".to_string(),
+        }
+    }
+
+    #[test]
+    fn delegation_is_always_registered() {
+        for verify in [false, true] {
+            for has_rdap in [false, true] {
+                assert_eq!(
+                    decide(&registered(), verify, has_rdap),
+                    Decision::Report("registered")
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn failure_is_always_failure() {
+        for verify in [false, true] {
+            for has_rdap in [false, true] {
+                assert_eq!(
+                    decide(&failure(), verify, has_rdap),
+                    Decision::Report("failure")
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn nxdomain_is_unconfirmed_without_verify() {
+        // The bug: a held domain answers NXDOMAIN. We must not call it available.
+        assert_eq!(
+            decide(&available(), false, true),
+            Decision::Report("unconfirmed")
+        );
+        assert_eq!(
+            decide(&available(), false, false),
+            Decision::Report("unconfirmed")
+        );
+    }
+
+    #[test]
+    fn nodata_is_unconfirmed_without_verify() {
+        assert_eq!(
+            decide(&nodata(), false, true),
+            Decision::Report("unconfirmed")
+        );
+        assert_eq!(
+            decide(&nodata(), false, false),
+            Decision::Report("unconfirmed")
+        );
+    }
+
+    #[test]
+    fn verify_confirms_only_when_rdap_available() {
+        assert_eq!(decide(&available(), true, true), Decision::Confirm);
+        assert_eq!(decide(&nodata(), true, true), Decision::Confirm);
+        // No RDAP endpoint for the zone: nothing to confirm against.
+        assert_eq!(
+            decide(&available(), true, false),
+            Decision::Report("unconfirmed")
+        );
+        assert_eq!(
+            decide(&nodata(), true, false),
+            Decision::Report("unconfirmed")
+        );
+    }
+
+    #[test]
+    fn rdap_404_is_the_only_path_to_available() {
+        let v = combine_rdap(
+            "NXDOMAIN via ns1",
+            Some(RdapOutcome::Available {
+                detail: "RDAP 404 via https://r".to_string(),
+            }),
+        );
+        assert_eq!(v.kind, "available");
+    }
+
+    #[test]
+    fn rdap_200_catches_held_domains_as_registered() {
+        let v = combine_rdap(
+            "NXDOMAIN via ns1",
+            Some(RdapOutcome::Registered {
+                detail: "RDAP 200 via https://r".to_string(),
+            }),
+        );
+        assert_eq!(v.kind, "registered");
+    }
+
+    #[test]
+    fn rdap_inconclusive_stays_unconfirmed() {
+        let v = combine_rdap("NXDOMAIN via ns1", None);
+        assert_eq!(v.kind, "unconfirmed");
+        assert!(v.detail.contains("RDAP inconclusive"));
     }
 }

--- a/crates/vacant/src/main.rs
+++ b/crates/vacant/src/main.rs
@@ -39,6 +39,12 @@ struct Cli {
     #[arg(long)]
     detail: bool,
 
+    /// Confirm undelegated names against the registry's RDAP endpoint. Without
+    /// this, names with no delegation report "unconfirmed" (probably free but
+    /// unverified); with it, they resolve to "available" or "registered".
+    #[arg(long)]
+    verify: bool,
+
     /// Disable on-disk result cache.
     #[arg(long)]
     no_cache: bool,
@@ -64,6 +70,8 @@ struct Cli {
     reserved: bool,
     #[arg(long)]
     invalid: bool,
+    #[arg(long)]
+    unconfirmed: bool,
     #[arg(long)]
     unknown: bool,
 }
@@ -121,6 +129,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         &inputs,
         cli.cache_ttl as i64,
         cli.concurrency,
+        cli.verify,
     );
 
     let filter = StatusFilter::from_cli(&cli);
@@ -156,6 +165,9 @@ impl StatusFilter {
         }
         if cli.invalid {
             allowed.push(Status::Invalid);
+        }
+        if cli.unconfirmed {
+            allowed.push(Status::Unconfirmed);
         }
         if cli.unknown {
             allowed.push(Status::Unknown);

--- a/crates/vacant/src/orchestrator.rs
+++ b/crates/vacant/src/orchestrator.rs
@@ -22,6 +22,7 @@ pub fn check_many(
     inputs: &[String],
     cache_ttl_secs: i64,
     concurrency: usize,
+    verify: bool,
 ) -> Vec<CheckResult> {
     let mut results: Vec<Option<CheckResult>> = vec![None; inputs.len()];
     let mut pending: Vec<(usize, String, String, Option<String>)> = Vec::new();
@@ -102,7 +103,7 @@ pub fn check_many(
                 rdap_url: rdap.clone(),
             })
             .collect();
-        let verdicts = dns.check_full_batch(jobs, concurrency);
+        let verdicts = dns.check_full_batch(jobs, concurrency, verify);
         for ((i, zone, registered, _), v) in pending.into_iter().zip(verdicts) {
             results[i] = Some(verdict_to_result(&inputs[i], zone, registered, v));
         }
@@ -110,7 +111,12 @@ pub fn check_many(
 
     if let Some(c) = cache {
         for r in results.iter().flatten() {
-            if r.from_cache || matches!(r.status, Status::Unknown | Status::Invalid) {
+            if r.from_cache
+                || matches!(
+                    r.status,
+                    Status::Unknown | Status::Invalid | Status::Unconfirmed
+                )
+            {
                 continue;
             }
             let _ = c.put(&r.domain, &r.zone, r.status.as_str(), &r.detail);
@@ -124,6 +130,7 @@ fn verdict_to_result(input: &str, zone: String, registered: String, v: FullVerdi
     let status = match v.kind {
         "registered" => Status::Registered,
         "available" => Status::Available,
+        "unconfirmed" => Status::Unconfirmed,
         _ => Status::Unknown,
     };
     CheckResult {
@@ -142,6 +149,7 @@ fn parse_status(s: &str) -> Status {
         "registered" => Status::Registered,
         "reserved" => Status::Reserved,
         "invalid" => Status::Invalid,
+        "unconfirmed" => Status::Unconfirmed,
         _ => Status::Unknown,
     }
 }

--- a/crates/vacant/src/rules.rs
+++ b/crates/vacant/src/rules.rs
@@ -13,6 +13,7 @@ pub enum Status {
     Registered,
     Reserved,
     Invalid,
+    Unconfirmed,
     Unknown,
 }
 
@@ -23,6 +24,7 @@ impl Status {
             Status::Registered => "registered",
             Status::Reserved => "reserved",
             Status::Invalid => "invalid",
+            Status::Unconfirmed => "unconfirmed",
             Status::Unknown => "unknown",
         }
     }

--- a/crates/vacant/tests/cache.rs
+++ b/crates/vacant/tests/cache.rs
@@ -36,7 +36,7 @@ fn invalid_below_registrable_does_not_poison_cache() {
     // 1) Seed the cache by checking a subdomain — precheck returns Invalid
     //    ("below the registrable level"). No DNS is needed for the verdict.
     let inputs = vec!["vacant.alltuner.com".to_string()];
-    let results = check_many(&rs, &dc, Some(&cache), &inputs, 86_400, 1);
+    let results = check_many(&rs, &dc, Some(&cache), &inputs, 86_400, 1, false);
     assert_eq!(results[0].status.as_str(), "invalid");
     assert_eq!(results[0].domain, "alltuner.com");
 

--- a/js/README.md
+++ b/js/README.md
@@ -55,7 +55,7 @@ const results = checkMany(['example.com'], { cache })
 1. Normalizes the input.
 2. Looks up cache; returns hits immediately.
 3. Runs a per-zone precheck (length, charset, reserved labels) from the bundled `rules.toml`.
-4. For inputs that pass, asks the parent zone's NS directly. NXDOMAIN → available; delegation → registered; ambiguous answers fall back to RDAP.
+4. For inputs that pass, asks the parent zone's NS directly. Delegation → `registered`; NXDOMAIN/NODATA → `unconfirmed` (not delegated, not verified). Pass `{ verify: true }` to confirm `unconfirmed` names against the registry's RDAP endpoint, promoting them to `available` (404) or `registered` (200, e.g. a held domain). `available` only ever means RDAP-confirmed.
 
 Cache shape, rules format, and verdict semantics are all the engine's — see [alltuner/vacant](https://github.com/alltuner/vacant) for the source of truth.
 

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -16,7 +16,7 @@ export interface CachedRowJs {
   checkedAt: number
 }
 
-export declare function checkMany(domains: Array<string>, concurrency?: number | undefined | null, timeout?: number | undefined | null, cache?: JsDiskCache | undefined | null, cacheTtl?: number | undefined | null): Array<CheckRow>
+export declare function checkMany(domains: Array<string>, concurrency?: number | undefined | null, timeout?: number | undefined | null, cache?: JsDiskCache | undefined | null, cacheTtl?: number | undefined | null, verify?: boolean | undefined | null): Array<CheckRow>
 
 export interface CheckRow {
   input: string

--- a/js/src/checker.ts
+++ b/js/src/checker.ts
@@ -10,6 +10,7 @@ export const Status = {
   REGISTERED: 'registered',
   RESERVED: 'reserved',
   INVALID: 'invalid',
+  UNCONFIRMED: 'unconfirmed',
   UNKNOWN: 'unknown',
 } as const
 
@@ -28,6 +29,7 @@ export interface CheckOptions {
   timeout?: number
   cache?: DiskCache | string | null
   cacheTtl?: number
+  verify?: boolean
 }
 
 export interface CheckManyOptions extends CheckOptions {
@@ -75,9 +77,16 @@ export function checkMany(
   options: CheckManyOptions = {},
 ): Result[] {
   ensureRulesLoaded()
-  const { timeout = 4.0, concurrency = 64, cache, cacheTtl = 86_400.0 } = options
+  const { timeout = 4.0, concurrency = 64, cache, cacheTtl = 86_400.0, verify = false } = options
   const rustCache = coerceCache(cache)
-  const rows = binding.checkMany(domains, concurrency, timeout, rustCache as never, cacheTtl)
+  const rows = binding.checkMany(
+    domains,
+    concurrency,
+    timeout,
+    rustCache as never,
+    cacheTtl,
+    verify,
+  )
   return rows.map(toResult)
 }
 

--- a/js/src/cli.ts
+++ b/js/src/cli.ts
@@ -10,10 +10,11 @@ interface ParsedArgs {
   output: 'jsonl' | 'text'
   concurrency: number
   timeout: number
+  verify: boolean
   showHelp: boolean
 }
 
-const HELP = `usage: vacant [-h] [-o {jsonl,text}] [--concurrency N] [--timeout SECONDS] [domains ...]
+const HELP = `usage: vacant [-h] [-o {jsonl,text}] [--concurrency N] [--timeout SECONDS] [--verify] [domains ...]
 
 Check domain availability via authoritative DNS.
 
@@ -26,6 +27,7 @@ options:
                         Output format (default: jsonl).
   --concurrency N       (default: 64)
   --timeout SECONDS     (default: 4.0)
+  --verify              Confirm undelegated names against the registry's RDAP endpoint.
 `
 
 function parseArgs(argv: string[]): ParsedArgs {
@@ -34,6 +36,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     output: 'jsonl',
     concurrency: 64,
     timeout: 4.0,
+    verify: false,
     showHelp: false,
   }
   for (let i = 0; i < argv.length; i++) {
@@ -70,6 +73,8 @@ function parseArgs(argv: string[]): ParsedArgs {
       const n = Number.parseFloat(arg.slice('--timeout='.length))
       if (!Number.isFinite(n) || n <= 0) throw new Error(`--timeout requires a positive number`)
       out.timeout = n
+    } else if (arg === '--verify') {
+      out.verify = true
     } else if (arg.startsWith('-')) {
       throw new Error(`unknown option: ${arg}`)
     } else {
@@ -126,6 +131,7 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
   const results = checkMany(inputs, {
     concurrency: parsed.concurrency,
     timeout: parsed.timeout,
+    verify: parsed.verify,
   })
   emit(results, parsed.output)
 

--- a/js/src/native.ts
+++ b/js/src/native.ts
@@ -37,6 +37,7 @@ export interface NativeBinding {
     timeout?: number,
     cache?: NativeDiskCache | null,
     cacheTtl?: number,
+    verify?: boolean,
   ): CheckRowNative[]
   DiskCache: {
     new (path?: string | null): NativeDiskCache

--- a/python/README.md
+++ b/python/README.md
@@ -53,7 +53,7 @@ results = check_many(["example.com"], cache=cache)
 1. Normalizes the input.
 2. Looks up cache; returns hits immediately.
 3. Runs a per-zone precheck (length, charset, reserved labels) from the bundled `rules.toml`.
-4. For inputs that pass, asks the parent zone's NS directly. NXDOMAIN → available; delegation → registered; ambiguous answers fall back to RDAP.
+4. For inputs that pass, asks the parent zone's NS directly. Delegation → `registered`; NXDOMAIN/NODATA → `unconfirmed` (not delegated, not verified). Pass `verify=True` to confirm `unconfirmed` names against the registry's RDAP endpoint, promoting them to `available` (404) or `registered` (200, e.g. a held domain). `available` only ever means RDAP-confirmed.
 
 Cache shape, rules format, and verdict semantics are all the engine's — see [alltuner/vacant](https://github.com/alltuner/vacant) for the source of truth.
 

--- a/python/vacant/_core.pyi
+++ b/python/vacant/_core.pyi
@@ -14,6 +14,7 @@ def check_many(
     timeout: float = 4.0,
     cache: DiskCache | None = None,
     cache_ttl: float = 86_400.0,
+    verify: bool = False,
 ) -> list[dict[str, Any]]: ...
 
 class DiskCache:

--- a/python/vacant/checker.py
+++ b/python/vacant/checker.py
@@ -14,6 +14,7 @@ class Status(enum.Enum):
     REGISTERED = "registered"
     RESERVED = "reserved"
     INVALID = "invalid"
+    UNCONFIRMED = "unconfirmed"
     UNKNOWN = "unknown"
 
 
@@ -57,6 +58,7 @@ def check_many(
     concurrency: int = 64,
     cache: "DiskCache | str | None" = None,
     cache_ttl: float = 86_400.0,
+    verify: bool = False,
 ) -> list[Result]:
     """Check a batch of domains end-to-end via the vacant engine. Order preserved."""
     _ensure_rules_loaded()
@@ -67,6 +69,7 @@ def check_many(
         timeout=timeout,
         cache=rust_cache,
         cache_ttl=cache_ttl,
+        verify=verify,
     )
     return [_to_result(r) for r in rows]
 
@@ -77,6 +80,7 @@ def check(
     timeout: float = 4.0,
     cache: "DiskCache | str | None" = None,
     cache_ttl: float = 86_400.0,
+    verify: bool = False,
 ) -> Result:
     return check_many(
         [domain],
@@ -84,6 +88,7 @@ def check(
         concurrency=1,
         cache=cache,
         cache_ttl=cache_ttl,
+        verify=verify,
     )[0]
 
 

--- a/python/vacant/cli.py
+++ b/python/vacant/cli.py
@@ -27,6 +27,11 @@ def main() -> None:
     )
     parser.add_argument("--concurrency", type=int, default=64)
     parser.add_argument("--timeout", type=float, default=4.0)
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Confirm undelegated names against the registry's RDAP endpoint.",
+    )
     args = parser.parse_args()
 
     inputs = list(args.domains) or [
@@ -37,7 +42,9 @@ def main() -> None:
         parser.print_help(sys.stderr)
         sys.exit(2)
 
-    results = check_many(inputs, concurrency=args.concurrency, timeout=args.timeout)
+    results = check_many(
+        inputs, concurrency=args.concurrency, timeout=args.timeout, verify=args.verify
+    )
 
     if args.output == "jsonl":
         for r in results:


### PR DESCRIPTION
## The bug

`vacant bingo.app` returned `available`, but the domain is registered (on `clientHold`). A held/suspended/pending-delete domain is pulled from the registry's published zone, so an authoritative NS query answers `NXDOMAIN` — byte-for-byte identical to a genuinely free name. The engine trusted `NXDOMAIN` as `available`, producing false positives.

There is **no** DNS-layer signal that separates the two — every record type (A/AAAA/SOA/TXT/MX/DS/CNAME/DNSKEY) returns `NXDOMAIN`, with NSEC3 proving non-existence either way. Only RDAP/WHOIS can tell them apart.

## The fix

Reframe the verdict model around what DNS can actually prove:

- delegation present → `registered` (hard fact)
- `NXDOMAIN`/`NODATA` → new **`unconfirmed`** status (not delegated, probably free, *unverified*) — no longer `available`
- `--verify` confirms `unconfirmed` names against the zone's RDAP endpoint → `available` (404) / `registered` (200, catches held domains) / stays `unconfirmed` (inconclusive or no endpoint)

So `available` now only ever means RDAP-confirmed registrable. Default mode does **zero** RDAP, so delegated (taken) names still cost nothing.

- `unconfirmed` is not cached and does not affect the exit code.
- Threaded through the CLI (`--verify`, `--unconfirmed` filter), Python, and JS packages, with docs.
- Pure decision logic (`decide`, `combine_rdap`) covered by unit tests in `dns.rs`.

## Verification

29 Rust tests (8 new), 6 Python, 3 JS, `just check` clean. End-to-end, all three CLIs agree: `bingo.app` → `unconfirmed` default / `registered` with `--verify`; a random free name → `unconfirmed` / `available` with `--verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)