### PR TITLE
docs: caveat that available isn't a registrability guarantee

### DIFF
--- a/crates/vacant/README.md
+++ b/crates/vacant/README.md
@@ -52,6 +52,13 @@ answer for a free name and a held/suspended/pending-delete one is identical
 promotes them to `available` (RDAP 404) or `registered` (RDAP 200, e.g. a domain
 on hold). `available` therefore only ever means RDAP-confirmed registrable.
 
+One caveat: RDAP-confirmed registrable is not a registrability guarantee. New
+gTLD registries — especially community/city zones like `.barcelona`, `.cat`,
+`.amsterdam`, `.berlin` — keep reservation and premium lists that aren't visible
+via DNS, WHOIS, or RDAP, so a name can read `available` here yet still be refused
+at checkout (e.g. `radio.barcelona`). Tracked for an in-engine fix in
+[#26](https://github.com/alltuner/vacant/issues/26).
+
 Exit codes: `0` on success, `2` if any result has `status=unknown` (transport
 failure, ambiguous registry response). `unconfirmed` is a normal result and does
 not affect the exit code.

--- a/js/README.md
+++ b/js/README.md
@@ -57,6 +57,8 @@ const results = checkMany(['example.com'], { cache })
 3. Runs a per-zone precheck (length, charset, reserved labels) from the bundled `rules.toml`.
 4. For inputs that pass, asks the parent zone's NS directly. Delegation → `registered`; NXDOMAIN/NODATA → `unconfirmed` (not delegated, not verified). Pass `{ verify: true }` to confirm `unconfirmed` names against the registry's RDAP endpoint, promoting them to `available` (404) or `registered` (200, e.g. a held domain). `available` only ever means RDAP-confirmed.
 
+`available` is not a registrability guarantee, though: new gTLD registries (especially community/city zones like `.barcelona`, `.cat`, `.amsterdam`, `.berlin`) keep reservation and premium lists invisible to DNS, WHOIS, and RDAP, so a name can read `available` yet still be refused at checkout (e.g. `radio.barcelona`). Tracked for an in-engine fix in [#26](https://github.com/alltuner/vacant/issues/26).
+
 Cache shape, rules format, and verdict semantics are all the engine's — see [alltuner/vacant](https://github.com/alltuner/vacant) for the source of truth.
 
 ## Supported platforms

--- a/python/README.md
+++ b/python/README.md
@@ -55,6 +55,8 @@ results = check_many(["example.com"], cache=cache)
 3. Runs a per-zone precheck (length, charset, reserved labels) from the bundled `rules.toml`.
 4. For inputs that pass, asks the parent zone's NS directly. Delegation → `registered`; NXDOMAIN/NODATA → `unconfirmed` (not delegated, not verified). Pass `verify=True` to confirm `unconfirmed` names against the registry's RDAP endpoint, promoting them to `available` (404) or `registered` (200, e.g. a held domain). `available` only ever means RDAP-confirmed.
 
+`available` is not a registrability guarantee, though: new gTLD registries (especially community/city zones like `.barcelona`, `.cat`, `.amsterdam`, `.berlin`) keep reservation and premium lists invisible to DNS, WHOIS, and RDAP, so a name can read `available` yet still be refused at checkout (e.g. `radio.barcelona`). Tracked for an in-engine fix in [#26](https://github.com/alltuner/vacant/issues/26).
+
 Cache shape, rules format, and verdict semantics are all the engine's — see [alltuner/vacant](https://github.com/alltuner/vacant) for the source of truth.
 
 ## Develop


### PR DESCRIPTION
Closes #84.

`available` (RDAP-confirmed) is not a registrability guarantee. New gTLD registries — especially community/city zones like `.barcelona`, `.cat`, `.amsterdam`, `.berlin` — keep reservation and premium lists that aren't visible via DNS, WHOIS, or RDAP, so a name can read `available` yet still be refused at checkout (the issue's concrete case: `radio.barcelona`).

Documents this caveat in all three package READMEs (Rust/CLI, Python, JS), cross-referencing the in-engine fix tracked in #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)