### PR TITLE
docs: link the hosted web UI from the package READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ pnpm dlx @alltuner/vacant example.com     # npm package via pnpm
 
 All variants share the same Rust engine, so results and flags are identical. The native binary (`brew` / `cargo`) is fastest to start; the runner variants are perfect for one-shots and CI.
 
+Prefer a browser? [**vacant.alltuner.com**](https://vacant.alltuner.com) is a hosted web UI built on these packages — a separate app for checking one name or hundreds at once, no install. (The packages here are the engine, CLI, and libraries; that site is just one example of something built with them.)
+
 ## For agents
 
 There's a ready-made agent skill at [`alltuner/skills`](https://github.com/alltuner/skills) so coding agents (Claude Code, etc.) can use `vacant` directly when checking domain availability:

--- a/crates/vacant/README.md
+++ b/crates/vacant/README.md
@@ -11,6 +11,8 @@ $ vacant anthropic.com testdomain.com3d ab.eu
 {"domain":"ab.eu","status":"reserved"}
 ```
 
+> **Prefer a browser?** [vacant.alltuner.com](https://vacant.alltuner.com) is a hosted web UI built on vacant — a separate app that uses this crate, not something it installs.
+
 ## Install
 
 ```bash

--- a/js/README.md
+++ b/js/README.md
@@ -8,6 +8,8 @@ JavaScript / TypeScript bindings for the [vacant](https://github.com/alltuner/va
 
 The package ships the same Rust engine compiled in via [napi-rs](https://napi.rs), with a small TypeScript facade and a `vacant` CLI entry point. Lockstep-versioned with the `vacant` crate: `@alltuner/vacant 0.4.x` wraps `vacant 0.4.x` (Rust) exactly.
 
+> **Prefer a browser?** [vacant.alltuner.com](https://vacant.alltuner.com) is a hosted web UI built on vacant — a separate app that uses this package, not something it installs.
+
 ## Install
 
 Pick the path that matches how you'll use it:

--- a/python/README.md
+++ b/python/README.md
@@ -7,6 +7,8 @@ Python bindings for the [vacant](https://github.com/alltuner/vacant) Rust engine
 
 The wheel ships the same Rust engine compiled in, with a small Python facade and a `vacant` CLI entry point. Lockstep-versioned with the `vacant` crate: `vacant 0.3.x` (Python) wraps `vacant 0.3.x` (Rust) exactly.
 
+> **Prefer a browser?** [vacant.alltuner.com](https://vacant.alltuner.com) is a hosted web UI built on vacant — a separate app that uses this package, not something it installs.
+
 ## Install
 
 Pick the path that matches how you'll use it:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/alltuner/vacant"
 Repository = "https://github.com/alltuner/vacant"
-Engine = "https://github.com/alltuner/vacant"
+"Hosted web UI" = "https://vacant.alltuner.com"
 
 [project.optional-dependencies]
 mcp = ["mcp>=1.27"]


### PR DESCRIPTION
Part of off-page SEO (alltuner/vacant-web#61) — add the highest-authority, fully-in-our-control backlinks to the hosted web UI.

- Add a clearly-worded pointer to **vacant.alltuner.com** from the top-level README and each package README (PyPI ← `python/README.md`, npm ← `js/README.md`, crates.io ← `crates/vacant/README.md` all render these on their index pages).
- Add a labeled **`Hosted web UI`** project URL on PyPI (`[project.urls]`), and drop the redundant duplicate URL.

**Wording is deliberate:** every mention frames the site as *"a hosted web UI built on vacant — a separate app that uses this package, not something it installs."* The packages are the engine/CLI/libraries; the site is just one example of something built with them. No `homepage` metadata was repointed (those stay on the repo) so nothing implies the package ships a frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)