### PR TITLE
feat: add MCP registry metadata (server.json + mcp-name)

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,3 +1,5 @@
+<!-- mcp-name: io.github.alltuner/vacant -->
+
 # vacant — domain availability via authoritative DNS
 
 [![PyPI](https://img.shields.io/pypi/v/vacant.svg)](https://pypi.org/project/vacant/)

--- a/server.json
+++ b/server.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.alltuner/vacant",
+  "description": "Fast domain-availability checker — queries authoritative TLD nameservers directly (no WHOIS, no rate limits), with optional RDAP confirmation. One tool: check_domains.",
+  "repository": {
+    "url": "https://github.com/alltuner/vacant",
+    "source": "github"
+  },
+  "version": "0.4.7",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "vacant",
+      "version": "0.4.7",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "--from",
+          "value": "vacant[mcp]"
+        }
+      ],
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Enables publishing vacant to the **official MCP registry** (registry.modelcontextprotocol.io), which auto-seeds downstream directories (glama.ai, mcp.so, LobeHub). Part of off-page SEO (alltuner/vacant-web#61).

- **`server.json`** (root) — describes the stdio MCP server per the `2025-12-11` schema: PyPI package `vacant`, run as `uvx --from 'vacant[mcp]' vacant mcp` (`runtimeArguments: --from vacant[mcp]`, `packageArguments: mcp`, `transport: stdio`).
- **`mcp-name: io.github.alltuner/vacant`** marker in the PyPI README (as an HTML comment — invisible on the page, but present in the README source the registry checks for ownership verification).

### Follow-up (not in this PR)
1. This needs to be **released to PyPI** so the `mcp-name` marker is live on the package page — the `feat` type triggers that `vacant-py` release.
2. Then run `mcp-publisher login github` (one-time OAuth as `alltuner`) + `mcp-publisher publish`.
3. Keep `server.json` `version` in sync with releases (currently `0.4.7`).

If the registry's verifier rejects the marker in a comment, switch it to a visible line — the `mcp-publisher` CLI validates and will say.

🤖 Generated with [Claude Code](https://claude.com/claude-code)