### PR TITLE
ci: serialize release runs with a concurrency guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,13 @@ permissions:
   contents: write
   pull-requests: write
 
+# Serialize release runs so back-to-back releases queue instead of contending
+# for the runner pool. cancel-in-progress stays false: an in-flight publish must
+# never be cancelled, or a version gets skipped (npm 0.4.8 was lost this way).
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem
`release.yml` had no `concurrency:` group, so back-to-back releases (e.g. a release-please PR merged while a previous release run is still publishing) contended for the GitHub-hosted runner pool. A queued publish job could be cancelled mid-flight — **npm 0.4.8 was skipped this way** (the version line went 0.4.7 → 0.4.9).

## Fix
Add a workflow-level concurrency group so release runs serialize/queue instead of contending:

```yaml
concurrency:
  group: release
  cancel-in-progress: false
```

`cancel-in-progress` stays **false** deliberately — an in-flight publish must never be cancelled. The in-progress run is protected; a newly triggered run queues behind it. Validated with `actionlint`.

## Follow-up (not in this PR)
npm `0.4.8` is still missing. If version continuity matters, backfill manually:
`gh workflow run release.yml -f js_tag=vacant-js-v0.4.8`

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)