### PR TITLE
ci: link package versions so dependents track the core

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -61,5 +61,12 @@
         { "type": "test",     "section": "Tests" }
       ]
     }
-  }
+  },
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "vacant",
+      "components": ["vacant", "vacant-py", "vacant-js"]
+    }
+  ]
 }


### PR DESCRIPTION
## Problem

The python wheel (`vacant-py` / PyPI `vacant`) and the js wrapper (`@alltuner/vacant`) both statically bundle the `crates/vacant` core via Cargo path dependencies. But release-please only bumps a package when a commit touches that package's own path, so a change to the core does **not** rebuild the dependents.

This is a live drift, not hypothetical: commit `a1df176` ("feat(rust,js): add mcp stdio server subcommand") landed in `crates/vacant` and bumped the core to **0.4.9**, but never touched `python/`, so the wheel stayed at **0.4.8**. PyPI `vacant` 0.4.8 therefore ships a core missing the mcp stdio server subcommand that's present in core 0.4.9.

## Fix

Add release-please's `linked-versions` plugin grouping `vacant` + `vacant-py` + `vacant-js`. Any release of one moves all three to the group's highest version, guaranteeing the wheel and wrapper always rebuild against the core they embed. Going forward the three published packages version in lockstep.

## Validation

- JSON syntactically valid.
- Validated against release-please's published config schema: `linked-versions` block has all required keys (`type`, `groupName`, `components`), correct types, no unknown keys.
- Component names (`vacant`, `vacant-py`, `vacant-js`) match the existing release tags.
- A full local `release-please --dry-run` was blocked by a local multi-host `gh` token quirk (GraphQL 401 from a stale `github.localhost` Enterprise token), not by this config. release-please next runs post-merge on push to `main`; a bad config would fail that step non-destructively (no release PR, existing artifacts untouched).

## Known residual gap (not addressed here)

A dependency bump that touches **only** the root `Cargo.lock` (a transitive update) still triggers no release, since it touches no package path. For the published library this is moot (Cargo.lock isn't published), and the binaries/wheels pick it up on the next real release or via the existing `workflow_dispatch` manual rebuild inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)