### PR TITLE
feat: per-zone forbidden-labels policy blocklist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,16 @@ jobs:
           diff -q rules/rules.toml python/vacant/rules.toml
           diff -q rules/rules.toml js/vacant/rules.toml
 
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v8.2.0
+
+      - name: Test ingest scripts
+        run: uv run --with pytest pytest ingest/tests
+
   rust:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/refresh-rules.yml
+++ b/.github/workflows/refresh-rules.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Refresh RDAP bootstrap and probe for omitted endpoints
         run: uv run ingest/rdap.py --probe
 
+      - name: Refresh registry-policy forbidden labels
+        run: uv run ingest/forbidden.py
+
       - name: Mirror canonical rules into every package
         run: just sync-rules
 
@@ -38,6 +41,7 @@ jobs:
             Weekly refresh of `rules/rules.toml` from upstream sources:
             - Public Suffix List ICANN section (`ingest/psl.py`)
             - IANA RDAP bootstrap, plus probed endpoints for TLDs it omits (`ingest/rdap.py --probe`)
+            - Registry-policy forbidden labels per registry handler (`ingest/forbidden.py`)
 
             The canonical file plus every embedded mirror is included in this PR.
             Bumped automatically by `.github/workflows/refresh-rules.yml`. Merge if CI is green.

--- a/Justfile
+++ b/Justfile
@@ -32,6 +32,14 @@ ingest-rdap *args:
 ingest-rdap-probe *args:
     uv run ingest/rdap.py --probe {{args}}
 
+# Refresh rules/rules.toml forbidden_labels from the per-registry handlers.
+ingest-forbidden *args:
+    uv run ingest/forbidden.py {{args}}
+
+# Test the ingest scripts.
+ingest-check:
+    uv run --with pytest pytest ingest/tests
+
 # Mirror rules/rules.toml into every package's embedded copy.
 sync-rules:
     cp rules/rules.toml crates/vacant/data/rules.toml

--- a/crates/vacant/data/rules.toml
+++ b/crates/vacant/data/rules.toml
@@ -23,6 +23,7 @@ rdap_probed_at = "2026-06-08T10:22:48Z"
 #   no_tagged_hyphen   bool   (forbid '-' at positions 3 and 4 unless 'xn--')
 #   pattern            regex  (label MUST match)
 #   forbid_pattern     regex  (label must NOT match)
+#   forbidden_labels   array  (labels reserved by registry policy; reported reserved)
 
 [default]
 min_length = 1

--- a/crates/vacant/data/rules.toml
+++ b/crates/vacant/data/rules.toml
@@ -13,6 +13,9 @@ psl_imported_at = "2026-06-08T10:22:02Z"
 rdap_publication = "2026-06-02T21:00:01Z"
 rdap_imported_at = "2026-06-08T10:22:48Z"
 rdap_probed_at = "2026-06-08T10:22:48Z"
+forbidden_nominet_count = 64
+forbidden_nominet_hash = "aa793b4828af623c"
+forbidden_nominet_fetched_at = "2026-06-15T09:07:18Z"
 #
 # Each zone inherits [default] and overrides what it cares about.
 # Recognised keys:
@@ -56,16 +59,20 @@ rdap = "https://pubapi.registry.google/rdap"
 [zone.uk]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."co.uk"]
+forbidden_labels = ["ac", "co", "com", "gov", "ltd", "me", "mil", "mod", "net", "nhs", "nic", "org", "plc", "police", "sch", "uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."org.uk"]
+forbidden_labels = ["ac", "co", "com", "gov", "ltd", "me", "mil", "mod", "net", "nhs", "nic", "org", "plc", "police", "sch", "uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."me.uk"]
+forbidden_labels = ["ac", "co", "com", "gov", "ltd", "me", "mil", "mod", "net", "nhs", "nic", "org", "plc", "police", "sch", "uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."ltd.uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."plc.uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."net.uk"]
+forbidden_labels = ["ac", "co", "com", "gov", "ltd", "me", "mil", "mod", "net", "nhs", "nic", "org", "plc", "police", "sch", "uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."ac.uk"]
 rdap = "https://rdap.nominet.uk/uk"

--- a/crates/vacant/src/orchestrator.rs
+++ b/crates/vacant/src/orchestrator.rs
@@ -52,21 +52,9 @@ pub fn check_many(
             continue;
         }
 
-        if let Some(c) = cache {
-            if let Ok(Some(row)) = c.get(&cleaned, cache_ttl_secs) {
-                let status = parse_status(&row.status);
-                results[i] = Some(CheckResult {
-                    input: raw.clone(),
-                    domain: row.domain,
-                    zone: row.zone,
-                    status,
-                    detail: row.detail,
-                    from_cache: true,
-                });
-                continue;
-            }
-        }
-
+        // Precheck is a pure in-memory verdict (Invalid/Reserved), so it is
+        // authoritative and runs before the cache: a deterministic policy
+        // verdict must never be masked by a stale network-derived cache row.
         match rules.precheck(&cleaned) {
             PreCheck::Verdict {
                 status,
@@ -89,6 +77,19 @@ pub fn check_many(
                 rdap,
                 ..
             } => {
+                if let Some(c) = cache {
+                    if let Ok(Some(row)) = c.get(&registered, cache_ttl_secs) {
+                        results[i] = Some(CheckResult {
+                            input: raw.clone(),
+                            domain: row.domain,
+                            zone: row.zone,
+                            status: parse_status(&row.status),
+                            detail: row.detail,
+                            from_cache: true,
+                        });
+                        continue;
+                    }
+                }
                 pending.push((i, zone, registered, rdap));
             }
         }
@@ -122,7 +123,7 @@ pub fn check_many(
             if r.from_cache
                 || matches!(
                     r.status,
-                    Status::Unknown | Status::Invalid | Status::Unconfirmed
+                    Status::Unknown | Status::Invalid | Status::Unconfirmed | Status::Reserved
                 )
             {
                 continue;

--- a/crates/vacant/src/rules.rs
+++ b/crates/vacant/src/rules.rs
@@ -1,7 +1,7 @@
 // ABOUTME: TOML-driven rules engine: zone matching plus per-zone label predicates.
 // ABOUTME: Ports the Python rules.py / checker pre-DNS path so the Rust engine can A/B against it.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use regex::Regex;
 use serde::Deserialize;
@@ -92,6 +92,7 @@ enum PredicateFn {
     NoTaggedHyphen,
     Pattern(Regex),
     ForbidPattern(Regex),
+    ForbiddenLabel(HashSet<String>),
 }
 
 impl Predicate {
@@ -115,6 +116,7 @@ impl Predicate {
             }
             PredicateFn::Pattern(re) => re.is_match(label) && full_match(re, label),
             PredicateFn::ForbidPattern(re) => !re.is_match(label),
+            PredicateFn::ForbiddenLabel(set) => !set.contains(label),
         }
     }
 }
@@ -305,6 +307,8 @@ struct RawSpec {
     #[serde(default)]
     forbid_pattern: Option<String>,
     #[serde(default)]
+    forbidden_labels: Option<Vec<String>>,
+    #[serde(default)]
     rdap: Option<String>,
 }
 
@@ -326,6 +330,10 @@ fn merge(default: &RawSpec, override_: &RawSpec) -> RawSpec {
             .forbid_pattern
             .clone()
             .or_else(|| default.forbid_pattern.clone()),
+        forbidden_labels: override_
+            .forbidden_labels
+            .clone()
+            .or_else(|| default.forbidden_labels.clone()),
         rdap: override_.rdap.clone().or_else(|| default.rdap.clone()),
     }
 }
@@ -387,6 +395,16 @@ fn build_policy(zone: &str, spec: &RawSpec, _root: &RawSpec) -> Result<ZonePolic
             message: format!("label must not match {pat}"),
             test: PredicateFn::ForbidPattern(re),
         });
+    }
+    if let Some(labels) = &spec.forbidden_labels {
+        let set: HashSet<String> = labels.iter().map(|l| l.to_ascii_lowercase()).collect();
+        if !set.is_empty() {
+            predicates.push(Predicate {
+                name: "forbidden-label",
+                message: "reserved by registry policy".to_string(),
+                test: PredicateFn::ForbiddenLabel(set),
+            });
+        }
     }
     Ok(ZonePolicy {
         zone: zone.to_string(),

--- a/crates/vacant/tests/cache.rs
+++ b/crates/vacant/tests/cache.rs
@@ -16,6 +16,9 @@ no_edge_hyphen = true
 no_tagged_hyphen = true
 
 [zone.com]
+
+[zone."co.uk"]
+forbidden_labels = ["gov"]
 "#;
 
 fn rules() -> RuleSet {
@@ -52,6 +55,28 @@ fn invalid_below_registrable_does_not_poison_cache() {
     // And nothing under the input-shape key either.
     let row = cache.get("vacant.alltuner.com", 86_400).expect("cache get");
     assert!(row.is_none());
+}
+
+#[test]
+fn forbidden_label_overrides_a_stale_available_cache_row() {
+    let tmp = TempDir::new().expect("tempdir");
+    let cache = DiskCache::open(&tmp.path().join("results.db")).expect("open cache");
+    let rs = rules();
+    let dc = dns();
+
+    // Seed a row as if gov.co.uk had been confirmed available before the label
+    // was added to the policy blocklist.
+    cache
+        .put("gov.co.uk", "co.uk", "available", "RDAP 404")
+        .expect("seed cache");
+
+    // Precheck must win: the deterministic policy verdict overrides the cache,
+    // and the result is not served from cache.
+    let inputs = vec!["gov.co.uk".to_string()];
+    let results = check_many(&rs, &dc, Some(&cache), &inputs, 86_400, 1, false);
+    assert_eq!(results[0].status.as_str(), "reserved");
+    assert!(!results[0].from_cache);
+    assert!(results[0].detail.contains("forbidden-label"));
 }
 
 #[test]

--- a/crates/vacant/tests/properties.rs
+++ b/crates/vacant/tests/properties.rs
@@ -231,3 +231,69 @@ proptest! {
         }
     }
 }
+
+const FORBIDDEN_FIXTURE: &str = r#"
+[default]
+min_length = 1
+max_length = 63
+charset = "ldh"
+
+[zone."co.uk"]
+forbidden_labels = ["gov", "police"]
+
+[zone.com]
+forbidden_labels = []
+"#;
+
+#[test]
+fn forbidden_label_is_reserved_without_dns() {
+    let rs = RuleSet::from_str(FORBIDDEN_FIXTURE).expect("fixture is valid");
+    match rs.precheck("gov.co.uk") {
+        PreCheck::Verdict {
+            status,
+            detail,
+            zone,
+            registered,
+        } => {
+            assert_eq!(status, Status::Reserved);
+            assert!(detail.contains("forbidden-label"), "got {detail}");
+            assert!(
+                detail.contains("reserved by registry policy"),
+                "got {detail}"
+            );
+            assert_eq!(zone, "co.uk");
+            assert_eq!(registered, "gov.co.uk");
+        }
+        other => panic!("expected reserved verdict, got {other:?}"),
+    }
+}
+
+#[test]
+fn forbidden_label_match_is_case_insensitive() {
+    let rs = RuleSet::from_str(FORBIDDEN_FIXTURE).expect("fixture is valid");
+    match rs.precheck("POLICE.co.uk") {
+        PreCheck::Verdict { status, .. } => assert_eq!(status, Status::Reserved),
+        other => panic!("expected reserved verdict, got {other:?}"),
+    }
+}
+
+#[test]
+fn non_forbidden_label_in_guarded_zone_proceeds() {
+    let rs = RuleSet::from_str(FORBIDDEN_FIXTURE).expect("fixture is valid");
+    match rs.precheck("acme.co.uk") {
+        PreCheck::Proceed { zone, label, .. } => {
+            assert_eq!(zone, "co.uk");
+            assert_eq!(label, "acme");
+        }
+        other => panic!("expected proceed, got {other:?}"),
+    }
+}
+
+#[test]
+fn empty_forbidden_labels_is_a_noop() {
+    let rs = RuleSet::from_str(FORBIDDEN_FIXTURE).expect("fixture is valid");
+    match rs.precheck("anything.com") {
+        PreCheck::Proceed { zone, .. } => assert_eq!(zone, "com"),
+        other => panic!("expected proceed, got {other:?}"),
+    }
+}

--- a/ingest/forbidden.py
+++ b/ingest/forbidden.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# ///
+# ABOUTME: Refresh rules/rules.toml forbidden_labels (labels reserved by registry policy).
+# ABOUTME: Run via `uv run ingest/forbidden.py [--dry-run] [--force]`. One handler per registry.
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+import rules_io
+
+RULES = Path(__file__).resolve().parent.parent / "rules" / "rules.toml"
+
+# A handler's output collapsing to nothing, or shrinking past this fraction of
+# what it last produced, is treated as a broken source rather than a real edit.
+SHRINK_GUARD_RATIO = 0.5
+
+
+@dataclass(frozen=True)
+class Result:
+    """One registry's verdict: the forbidden labels it owns, keyed by zone."""
+
+    registry: str
+    zones: dict[str, list[str]]
+
+    def label_count(self) -> int:
+        return sum(len(labels) for labels in self.zones.values())
+
+    def content_hash(self) -> str:
+        canonical = json.dumps(
+            {zone: sorted(labels) for zone, labels in self.zones.items()},
+            sort_keys=True,
+        )
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+# Nominet "Rules of Registration" (current revision 20.03.2024), Rule 5.5 + 5.6:
+# https://www.nominet.uk/uk-domains/policies/
+# Rule 5.5 forbids the existing-SLD labels, Rule 5.6 forbids "com" and "uk", both
+# as a third-level label within the co.uk / me.uk / org.uk / net.uk zones. The set
+# is closed and changes on a multi-year cadence, so it is pinned here with a manual
+# re-check cadence rather than scraped from the (URL-unstable) policy PDF.
+_RULE_5_5 = (
+    "ac",
+    "co",
+    "gov",
+    "ltd",
+    "me",
+    "mil",
+    "mod",
+    "net",
+    "nhs",
+    "nic",
+    "org",
+    "plc",
+    "police",
+    "sch",
+)
+_RULE_5_6 = ("com", "uk")
+_NOMINET_LABELS = sorted(_RULE_5_5 + _RULE_5_6)
+_NOMINET_ZONES = ("co.uk", "me.uk", "org.uk", "net.uk")
+
+
+def nominet() -> Result:
+    return Result("nominet", {zone: list(_NOMINET_LABELS) for zone in _NOMINET_ZONES})
+
+
+# Adding a registry = adding a handler above and one entry here. Nothing else.
+HANDLERS: tuple[Callable[[], Result], ...] = (nominet,)
+
+
+def guard(result: Result, meta: dict) -> str | None:
+    """Reject output that looks like a broken source. Returns an error or None."""
+    previous = meta.get(f"forbidden_{result.registry}_count")
+    if not isinstance(previous, int) or previous <= 0:
+        return None  # nothing to compare against (first run)
+    current = result.label_count()
+    if current == 0:
+        return f"{result.registry}: produced 0 labels, previously {previous}"
+    if current < previous * SHRINK_GUARD_RATIO:
+        return f"{result.registry}: produced {current} labels, previously {previous} (>50% drop)"
+    return None
+
+
+def compute_changes(
+    zones: dict, desired: dict[str, list[str]]
+) -> list[tuple[str, list[str] | None, list[str]]]:
+    """Zones whose forbidden_labels should change, as (zone, old, new)."""
+    changes: list[tuple[str, list[str] | None, list[str]]] = []
+    for zone_name, labels in sorted(desired.items()):
+        current = zones.get(zone_name, {}).get("forbidden_labels")
+        if current == labels:
+            continue
+        changes.append((zone_name, current, labels))
+    return changes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="Show changes without writing")
+    parser.add_argument("--force", action="store_true", help="Write even if nothing changed")
+    args = parser.parse_args()
+
+    raw = RULES.read_text(encoding="utf-8")
+    data = rules_io.load(raw)
+    meta = data.get("meta", {})
+    zones = data.get("zone", {})
+
+    results = [handler() for handler in HANDLERS]
+
+    failures = [msg for r in results if (msg := guard(r, meta)) is not None]
+    if failures:
+        for msg in failures:
+            sys.stderr.write(f"refusing to write — {msg}\n")
+        sys.stderr.write("source looks broken; investigate before refreshing\n")
+        return 1
+
+    missing = [f"{r.registry}:{zone}" for r in results for zone in r.zones if zone not in zones]
+    if missing:
+        sys.stderr.write(f"target zone(s) not in rules.toml: {', '.join(missing)}\n")
+        return 1
+
+    desired: dict[str, list[str]] = {}
+    for r in results:
+        desired.update(r.zones)
+
+    changes = compute_changes(zones, desired)
+    for zone, old, new in changes:
+        sys.stdout.write(f"{zone}: {old if old is not None else '(unset)'} -> {new}\n")
+    sys.stdout.write(
+        f"{len(changes)} zone(s) updated{'; dry-run, not writing' if args.dry_run else ''}\n"
+    )
+
+    if not changes and not args.force:
+        return 0
+    if args.dry_run:
+        return 0
+
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    meta_updates: dict[str, object] = {}
+    for r in results:
+        meta_updates[f"forbidden_{r.registry}_count"] = r.label_count()
+        meta_updates[f"forbidden_{r.registry}_hash"] = r.content_hash()
+        meta_updates[f"forbidden_{r.registry}_fetched_at"] = now
+    text = rules_io.apply_edits(
+        raw,
+        meta=meta_updates,
+        zone_forbidden={zone: new for zone, _, new in changes},
+    )
+    RULES.write_text(text, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ingest/rules_io.py
+++ b/ingest/rules_io.py
@@ -9,6 +9,7 @@ import tomllib
 _ZONE_HEADER = re.compile(r'^\[zone\.(?:"([^"]+)"|([A-Za-z0-9_-]+))\]$')
 _KEY = re.compile(r"^([A-Za-z0-9_]+) = ")
 _RDAP = re.compile(r"^rdap = ")
+_FORBIDDEN = re.compile(r"^forbidden_labels = ")
 _BARE_KEY = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
@@ -25,6 +26,10 @@ def _format_value(value: object) -> str:
     return '"' + str(value) + '"'
 
 
+def _format_label_list(labels: list[str]) -> str:
+    return "[" + ", ".join('"' + label + '"' for label in labels) + "]"
+
+
 def zone_header(name: str) -> str:
     """The `[zone.<name>]` header as TOML writes it: bare key, or quoted if it has dots."""
     if _BARE_KEY.fullmatch(name):
@@ -37,6 +42,7 @@ def apply_edits(
     *,
     meta: dict[str, object] | None = None,
     zone_rdap: dict[str, str] | None = None,
+    zone_forbidden: dict[str, list[str]] | None = None,
     new_zones: list[str] | None = None,
 ) -> str:
     """Return `text` with the requested edits applied, touching only changed lines.
@@ -44,17 +50,21 @@ def apply_edits(
     - `meta`: replace these keys' values in the `[meta]` table.
     - `zone_rdap`: set each zone's `rdap` (replacing any existing value, inserted
       right after the header so it leads the block).
+    - `zone_forbidden`: set each zone's `forbidden_labels` array (replacing any
+      existing value, inserted right after the header).
     - `new_zones`: append these as empty `[zone.<name>]` blocks at the end.
 
     Passing no edits returns the input unchanged byte-for-byte.
     """
     meta = dict(meta or {})
     zone_rdap = dict(zone_rdap or {})
+    zone_forbidden = dict(zone_forbidden or {})
     new_zones = list(new_zones or [])
 
     out: list[str] = []
     in_meta = False
     drop_rdap = False  # inside a zone we're rewriting: drop its existing rdap line
+    drop_forbidden = False  # likewise for its existing forbidden_labels line
     meta_remaining = dict(meta)  # keys not found in [meta] get appended on the way out
     last_meta_idx: int | None = None  # index in `out` just after the last [meta] key
 
@@ -73,6 +83,7 @@ def apply_edits(
                 flush_meta()  # leaving [meta]: append any keys it didn't already have
             in_meta = header == "[meta]"
             drop_rdap = False
+            drop_forbidden = False
             out.append(line)
             match = _ZONE_HEADER.match(header)
             if match:
@@ -80,6 +91,9 @@ def apply_edits(
                 if name in zone_rdap:
                     out.append(f'rdap = "{zone_rdap[name]}"')
                     drop_rdap = True
+                if name in zone_forbidden:
+                    out.append(f"forbidden_labels = {_format_label_list(zone_forbidden[name])}")
+                    drop_forbidden = True
             continue
 
         if in_meta:
@@ -94,6 +108,8 @@ def apply_edits(
                 continue
 
         if drop_rdap and _RDAP.match(line):
+            continue  # superseded by the line inserted after the header
+        if drop_forbidden and _FORBIDDEN.match(line):
             continue  # superseded by the line inserted after the header
 
         out.append(line)

--- a/ingest/tests/conftest.py
+++ b/ingest/tests/conftest.py
@@ -1,0 +1,6 @@
+# ABOUTME: Makes the ingest scripts importable as modules for the test suite.
+# ABOUTME: Adds the ingest directory to sys.path so `import rules_io` / `forbidden` resolve.
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/ingest/tests/test_forbidden.py
+++ b/ingest/tests/test_forbidden.py
@@ -1,0 +1,86 @@
+# ABOUTME: Tests for the registry-policy forbidden-label ingest tool.
+# ABOUTME: Covers the Nominet handler, sanity guard, change detection, and the write path.
+from __future__ import annotations
+
+import sys
+import tomllib
+
+import forbidden
+
+
+def test_nominet_covers_the_four_zones():
+    result = forbidden.nominet()
+    assert set(result.zones) == {"co.uk", "me.uk", "org.uk", "net.uk"}
+    for labels in result.zones.values():
+        assert "gov" in labels
+        assert labels == sorted(labels)
+        assert len(labels) == 16
+
+
+def test_label_count_and_hash_are_stable():
+    a = forbidden.nominet()
+    b = forbidden.nominet()
+    assert a.label_count() == 64  # 16 labels across 4 zones
+    assert a.content_hash() == b.content_hash()
+
+
+def test_guard_passes_on_first_run():
+    assert forbidden.guard(forbidden.nominet(), {}) is None
+
+
+def test_guard_passes_when_count_is_stable():
+    result = forbidden.nominet()
+    assert forbidden.guard(result, {"forbidden_nominet_count": result.label_count()}) is None
+
+
+def test_guard_rejects_collapse_to_zero():
+    empty = forbidden.Result("nominet", {"co.uk": []})
+    assert forbidden.guard(empty, {"forbidden_nominet_count": 64}) is not None
+
+
+def test_guard_rejects_large_shrink():
+    shrunk = forbidden.Result("nominet", {"co.uk": ["gov"]})  # 1 vs prior 64
+    assert forbidden.guard(shrunk, {"forbidden_nominet_count": 64}) is not None
+
+
+def test_compute_changes_detects_unset_and_skips_equal():
+    desired = {"co.uk": ["gov"]}
+    assert forbidden.compute_changes({}, desired) == [("co.uk", None, ["gov"])]
+    unchanged = forbidden.compute_changes({"co.uk": {"forbidden_labels": ["gov"]}}, desired)
+    assert unchanged == []
+
+
+def _fixture(rules):
+    rules.write_text(
+        '[meta]\npsl_version = "x"\n\n'
+        '[zone."co.uk"]\n[zone."me.uk"]\n[zone."org.uk"]\n[zone."net.uk"]\n',
+        encoding="utf-8",
+    )
+
+
+def test_main_populates_then_is_idempotent(tmp_path, monkeypatch, capsys):
+    rules = tmp_path / "rules.toml"
+    _fixture(rules)
+    monkeypatch.setattr(forbidden, "RULES", rules)
+    monkeypatch.setattr(sys, "argv", ["forbidden.py"])
+
+    assert forbidden.main() == 0
+    data = tomllib.loads(rules.read_text())
+    assert "gov" in data["zone"]["co.uk"]["forbidden_labels"]
+    assert data["meta"]["forbidden_nominet_count"] == 64
+
+    before = rules.read_text()
+    capsys.readouterr()  # drop the first run's output
+    assert forbidden.main() == 0
+    assert rules.read_text() == before  # nothing rewritten
+    assert "0 zone(s) updated" in capsys.readouterr().out
+
+
+def test_main_refuses_when_target_zone_missing(tmp_path, monkeypatch):
+    rules = tmp_path / "rules.toml"
+    rules.write_text('[meta]\n\n[zone."co.uk"]\n', encoding="utf-8")  # me/org/net.uk absent
+    monkeypatch.setattr(forbidden, "RULES", rules)
+    monkeypatch.setattr(sys, "argv", ["forbidden.py"])
+    assert forbidden.main() == 1
+    # the file is untouched on refusal
+    assert "forbidden_labels" not in rules.read_text()

--- a/ingest/tests/test_rules_io.py
+++ b/ingest/tests/test_rules_io.py
@@ -1,0 +1,77 @@
+# ABOUTME: Tests for the format-preserving rules.toml editor.
+# ABOUTME: Covers the forbidden_labels writer plus idempotency and no-op guarantees.
+from __future__ import annotations
+
+import tomllib
+
+import rules_io
+
+BASE = """[meta]
+psl_version = "x"
+
+[zone.com]
+rdap = "https://rdap.verisign.com/com/v1"
+
+[zone."co.uk"]
+rdap = "https://rdap.nominet.uk/uk"
+
+[zone."org.uk"]
+rdap = "https://rdap.nominet.uk/uk"
+forbidden_labels = ["old"]
+"""
+
+
+def test_noop_returns_input_byte_for_byte():
+    assert rules_io.apply_edits(BASE) == BASE
+
+
+def test_zone_forbidden_inserts_when_absent():
+    out = rules_io.apply_edits(BASE, zone_forbidden={"co.uk": ["ac", "gov"]})
+    data = tomllib.loads(out)
+    assert data["zone"]["co.uk"]["forbidden_labels"] == ["ac", "gov"]
+    # the zone's existing rdap is preserved
+    assert data["zone"]["co.uk"]["rdap"] == "https://rdap.nominet.uk/uk"
+
+
+def test_zone_forbidden_replaces_existing():
+    out = rules_io.apply_edits(BASE, zone_forbidden={"org.uk": ["gov", "police"]})
+    data = tomllib.loads(out)
+    assert data["zone"]["org.uk"]["forbidden_labels"] == ["gov", "police"]
+    # the old value is dropped, not duplicated
+    assert out.count("forbidden_labels = ") == 1
+
+
+def test_untouched_zone_is_left_alone():
+    out = rules_io.apply_edits(BASE, zone_forbidden={"co.uk": ["gov"]})
+    data = tomllib.loads(out)
+    assert data["zone"]["com"]["rdap"] == "https://rdap.verisign.com/com/v1"
+    assert "forbidden_labels" not in data["zone"]["com"]
+
+
+def test_zone_forbidden_is_idempotent():
+    edit = {"co.uk": ["ac", "gov"], "org.uk": ["gov", "police"]}
+    once = rules_io.apply_edits(BASE, zone_forbidden=edit)
+    twice = rules_io.apply_edits(once, zone_forbidden=edit)
+    assert once == twice
+
+
+def test_rdap_and_forbidden_on_same_zone():
+    out = rules_io.apply_edits(
+        BASE,
+        zone_rdap={"co.uk": "https://example/rdap"},
+        zone_forbidden={"co.uk": ["gov"]},
+    )
+    data = tomllib.loads(out)
+    assert data["zone"]["co.uk"]["rdap"] == "https://example/rdap"
+    assert data["zone"]["co.uk"]["forbidden_labels"] == ["gov"]
+
+
+def test_new_meta_keys_are_appended():
+    out = rules_io.apply_edits(BASE, meta={"forbidden_x_count": 3})
+    data = tomllib.loads(out)
+    assert data["meta"]["forbidden_x_count"] == 3
+
+
+def test_format_label_list():
+    assert rules_io._format_label_list(["a", "b"]) == '["a", "b"]'
+    assert rules_io._format_label_list([]) == "[]"

--- a/js/vacant/rules.toml
+++ b/js/vacant/rules.toml
@@ -23,6 +23,7 @@ rdap_probed_at = "2026-06-08T10:22:48Z"
 #   no_tagged_hyphen   bool   (forbid '-' at positions 3 and 4 unless 'xn--')
 #   pattern            regex  (label MUST match)
 #   forbid_pattern     regex  (label must NOT match)
+#   forbidden_labels   array  (labels reserved by registry policy; reported reserved)
 
 [default]
 min_length = 1

--- a/js/vacant/rules.toml
+++ b/js/vacant/rules.toml
@@ -13,6 +13,9 @@ psl_imported_at = "2026-06-08T10:22:02Z"
 rdap_publication = "2026-06-02T21:00:01Z"
 rdap_imported_at = "2026-06-08T10:22:48Z"
 rdap_probed_at = "2026-06-08T10:22:48Z"
+forbidden_nominet_count = 64
+forbidden_nominet_hash = "aa793b4828af623c"
+forbidden_nominet_fetched_at = "2026-06-15T09:07:18Z"
 #
 # Each zone inherits [default] and overrides what it cares about.
 # Recognised keys:
@@ -56,16 +59,20 @@ rdap = "https://pubapi.registry.google/rdap"
 [zone.uk]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."co.uk"]
+forbidden_labels = ["ac", "co", "com", "gov", "ltd", "me", "mil", "mod", "net", "nhs", "nic", "org", "plc", "police", "sch", "uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."org.uk"]
+forbidden_labels = ["ac", "co", "com", "gov", "ltd", "me", "mil", "mod", "net", "nhs", "nic", "org", "plc", "police", "sch", "uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."me.uk"]
+forbidden_labels = ["ac", "co", "com", "gov", "ltd", "me", "mil", "mod", "net", "nhs", "nic", "org", "plc", "police", "sch", "uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."ltd.uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."plc.uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."net.uk"]
+forbidden_labels = ["ac", "co", "com", "gov", "ltd", "me", "mil", "mod", "net", "nhs", "nic", "org", "plc", "police", "sch", "uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."ac.uk"]
 rdap = "https://rdap.nominet.uk/uk"

--- a/python/vacant/rules.toml
+++ b/python/vacant/rules.toml
@@ -23,6 +23,7 @@ rdap_probed_at = "2026-06-08T10:22:48Z"
 #   no_tagged_hyphen   bool   (forbid '-' at positions 3 and 4 unless 'xn--')
 #   pattern            regex  (label MUST match)
 #   forbid_pattern     regex  (label must NOT match)
+#   forbidden_labels   array  (labels reserved by registry policy; reported reserved)
 
 [default]
 min_length = 1

--- a/python/vacant/rules.toml
+++ b/python/vacant/rules.toml
@@ -13,6 +13,9 @@ psl_imported_at = "2026-06-08T10:22:02Z"
 rdap_publication = "2026-06-02T21:00:01Z"
 rdap_imported_at = "2026-06-08T10:22:48Z"
 rdap_probed_at = "2026-06-08T10:22:48Z"
+forbidden_nominet_count = 64
+forbidden_nominet_hash = "aa793b4828af623c"
+forbidden_nominet_fetched_at = "2026-06-15T09:07:18Z"
 #
 # Each zone inherits [default] and overrides what it cares about.
 # Recognised keys:
@@ -56,16 +59,20 @@ rdap = "https://pubapi.registry.google/rdap"
 [zone.uk]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."co.uk"]
+forbidden_labels = ["ac", "co", "com", "gov", "ltd", "me", "mil", "mod", "net", "nhs", "nic", "org", "plc", "police", "sch", "uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."org.uk"]
+forbidden_labels = ["ac", "co", "com", "gov", "ltd", "me", "mil", "mod", "net", "nhs", "nic", "org", "plc", "police", "sch", "uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."me.uk"]
+forbidden_labels = ["ac", "co", "com", "gov", "ltd", "me", "mil", "mod", "net", "nhs", "nic", "org", "plc", "police", "sch", "uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."ltd.uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."plc.uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."net.uk"]
+forbidden_labels = ["ac", "co", "com", "gov", "ltd", "me", "mil", "mod", "net", "nhs", "nic", "org", "plc", "police", "sch", "uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."ac.uk"]
 rdap = "https://rdap.nominet.uk/uk"

--- a/rules/rules.toml
+++ b/rules/rules.toml
@@ -23,6 +23,7 @@ rdap_probed_at = "2026-06-08T10:22:48Z"
 #   no_tagged_hyphen   bool   (forbid '-' at positions 3 and 4 unless 'xn--')
 #   pattern            regex  (label MUST match)
 #   forbid_pattern     regex  (label must NOT match)
+#   forbidden_labels   array  (labels reserved by registry policy; reported reserved)
 
 [default]
 min_length = 1

--- a/rules/rules.toml
+++ b/rules/rules.toml
@@ -13,6 +13,9 @@ psl_imported_at = "2026-06-08T10:22:02Z"
 rdap_publication = "2026-06-02T21:00:01Z"
 rdap_imported_at = "2026-06-08T10:22:48Z"
 rdap_probed_at = "2026-06-08T10:22:48Z"
+forbidden_nominet_count = 64
+forbidden_nominet_hash = "aa793b4828af623c"
+forbidden_nominet_fetched_at = "2026-06-15T09:07:18Z"
 #
 # Each zone inherits [default] and overrides what it cares about.
 # Recognised keys:
@@ -56,16 +59,20 @@ rdap = "https://pubapi.registry.google/rdap"
 [zone.uk]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."co.uk"]
+forbidden_labels = ["ac", "co", "com", "gov", "ltd", "me", "mil", "mod", "net", "nhs", "nic", "org", "plc", "police", "sch", "uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."org.uk"]
+forbidden_labels = ["ac", "co", "com", "gov", "ltd", "me", "mil", "mod", "net", "nhs", "nic", "org", "plc", "police", "sch", "uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."me.uk"]
+forbidden_labels = ["ac", "co", "com", "gov", "ltd", "me", "mil", "mod", "net", "nhs", "nic", "org", "plc", "police", "sch", "uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."ltd.uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."plc.uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."net.uk"]
+forbidden_labels = ["ac", "co", "com", "gov", "ltd", "me", "mil", "mod", "net", "nhs", "nic", "org", "plc", "police", "sch", "uk"]
 rdap = "https://rdap.nominet.uk/uk"
 [zone."ac.uk"]
 rdap = "https://rdap.nominet.uk/uk"


### PR DESCRIPTION
Closes #26.

Some labels read as available over DNS and RDAP yet are reserved by registry policy — e.g. `gov.co.uk` returns NODATA + RDAP 404, but Nominet reserves the label, so `--verify` confirmed it as available. The engine had no authority for policy reservations. This adds one.

## What changed

- **Rules core** — new `forbidden_labels` array per zone, evaluated as a `PredicateFn::ForbiddenLabel` in precheck before any DNS/RDAP. A match short-circuits to `Status::Reserved` (`forbidden-label: reserved by registry policy`), covering both default and `--verify` modes. FFI bindings need no changes — they already surface `Reserved`.
- **Ingest** — `ingest/forbidden.py`: a registry→handler table emitting `forbidden_labels` per zone, with the same dry-run/force/skip-when-unchanged shape as `psl.py`/`rdap.py`. Records per-registry count, content hash, and `fetched_at` in `[meta]`; a sanity guard refuses to write when a handler's output collapses to zero or shrinks past half its prior size. The Nominet handler pins the closed Rule 5.5/5.6 reserved-label set across `co.uk`/`me.uk`/`org.uk`/`net.uk` — there is no machine-readable upstream and the policy PDF's URL drifts, so it is hardcoded with a manual re-check cadence rather than scraped.
- **rules_io** — `apply_edits` gained a `zone_forbidden` writer (mirrors `zone_rdap`, preserves the file's minimal-diff property).
- **Workflow** — `forbidden.py` runs in the weekly `refresh-rules` job; it is a no-op when nothing changed, so no PR churn for pinned lists.
- **Cache ordering fix** — precheck now runs before the disk cache so a deterministic policy verdict can't be masked by a stale network-derived row (e.g. an `available` `gov.co.uk` cached before the label joined the blocklist). The cache is consulted only for DNS-bound names; `Reserved` is no longer cached.
- **Tests** — Rust property + cache regression coverage; a new pytest suite for `rules_io` and `forbidden.py`, wired into a CI `ingest` job and `just ingest-check`.

## Verification

`gov.co.uk` now reports `reserved` (detail `forbidden-label: reserved by registry policy`) in both default and `--verify` mode, instantly, with no DNS. `acme.co.uk` still resolves normally. All Rust tests + 17 ingest tests pass; `just check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)