### PR TITLE
ci: skip CI jobs on github-actions[bot] pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   rules-sync:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -22,6 +23,7 @@ jobs:
           diff -q rules/rules.toml js/vacant/rules.toml
 
   ingest:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -32,6 +34,7 @@ jobs:
         run: uv run --with pytest pytest ingest/tests
 
   rust:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -55,6 +58,7 @@ jobs:
         run: cargo test --release --workspace
 
   python:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -86,6 +90,7 @@ jobs:
         working-directory: python
 
   javascript:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

release-please opens its `chore: release main` PRs as `github-actions[bot]`. Every such PR leaves an "awaiting approval" CI run (e.g. on #133, #136), because workflow runs on the bot's PRs require manual maintainer approval. Those PRs only bump versions/changelogs — content already validated by the feature PR's CI and re-validated by the push-to-`main` run after merge — so the CI matrix is redundant there.

## Change

Guard each `ci.yml` job with `if: github.actor != 'github-actions[bot]'`. The bot's release PRs skip the jobs; human and Renovate (`renovate[bot]`) PRs are unaffected, and push-to-`main` runs (actor = the merger) still run the full matrix.

## Caveat (to verify by observation)

GitHub determines the workflow-approval requirement from the PR actor at the **run** level, so this job-level guard reliably skips the *jobs* but may not remove the "awaiting approval" prompt on the run itself. If the gate persists after merge, the remaining lever is the repository's Actions approval *setting*, not the workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)