### PR TITLE
docs: add terminal demo to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
   <img src="https://img.shields.io/github/stars/alltuner/vacant?color=5B2333" alt="Stars">
 </p>
 
+<p align="center">
+  <img src="https://vacant.alltuner.com/static/demo.gif" alt="vacant checking domain availability" width="800">
+</p>
+
 ---
 
 ## Get Started


### PR DESCRIPTION
Embeds the vacant terminal demo (recorded with VHS: a single JSON check plus a `--verify` table showing the registered/available split) in the README hero.

Served from `https://vacant.alltuner.com/static/demo.gif` (behind Cloudflare, like the logo) — the asset lives in `alltuner/vacant-web` and is already live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qis2PweiMmE18kRQ1RnRt2